### PR TITLE
Bug fixes in Unicode.xs

### DIFF
--- a/Unicode/Unicode.xs
+++ b/Unicode/Unicode.xs
@@ -356,7 +356,7 @@ CODE:
 		if (ucs2 == -1) {
 		    ucs2 = SvTRUE(attr("ucs2", 4));
 		}
-		if (ucs2) {
+		if (ucs2 || ord > 0x10FFFF) {
 		    if (check) {
 			croak("%"SVf":code point \"\\x{%"UVxf"}\" too high",
 				  *hv_fetch((HV *)SvRV(obj),"Name",4,0),ord);

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -20,7 +20,7 @@ BEGIN {
 
 use strict;
 #use Test::More 'no_plan';
-use Test::More tests => 54;
+use Test::More tests => 56;
 use Encode qw(encode decode find_encoding);
 
 #
@@ -114,6 +114,18 @@ is(index($@, 'UCS-2LE'), 0, "encode UCS-2LE: exception");
           "decode $enc (HI surrogate)");
         is(decode($enc, pack($pack, 0x263A, 0xD800)), "\x{263A}\x{FFFD}",
           "decode $enc (WHITE SMILING FACE followed by HI surrogate)");
+    }
+}
+
+{
+    my %tests = (
+        'UTF-16BE' => 'n*',
+        'UTF-16LE' => 'v*',
+    );
+
+    while (my ($enc, $pack) = each(%tests)) {
+        is(encode($enc, "\x{110000}"), pack($pack, 0xFFFD), 
+          "ordinals greater than U+10FFFF is replaced with U+FFFD");
     }
 }
 


### PR DESCRIPTION
UTF-16
Fixed an issue where Unicode.xs produced ill-formed UTF-16 when attempting
to encode code points above U+10FFFF. Code points above U+10FFFF is now
correctly replaced with U+FFFD.

UTF-16
Fixed an issue where Unicode.xs ignored trailing high surrogates when
decoding. Trailing high surrogates is now correctly replaced with
U+FFFD unless the ENCODE_STOP_AT_PARTIAL flag is set.

UCS-2, UTF-16, UTF-32
Fixed an issue where Unicode.xs assumed high surrogate was followed by a low
surrogate, this resulted in data loss when isolated high surrogates (ill-formed)
where decoded. <0xD800 0x263A> is now correctly decoded as "\x{FFFD}\x{263A}",
previously it was decoded as "\x{FFFD}".
