### PR TITLE
Do not short-circuit decode_utf8 with utf8 flags

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -209,7 +209,6 @@ my $utf8enc;
 
 sub decode_utf8($;$) {
     my ( $octets, $check ) = @_;
-    return $octets if is_utf8($octets);
     return undef unless defined $octets;
     $octets .= '' if ref $octets;
     $check   ||= 0;


### PR DESCRIPTION
The documentation about `decode_utf8` says:

```
decode_utf8
    $string = decode_utf8($octets [, CHECK]);
Equivalent to "$string = decode("utf8", $octets [, CHECK])". 
```

which is not true, because it bypasses the whole decoding process if `$octet` already has utf-8 flags.

I think it's incorrect to bypass the decoding depending on the utf-8 flags, since a) it will emit unreliable, inconsistent results depending on how the byte string has been generated, and b) it's not consistent to `decode("utf8", $octets)` in any ways.

This patch eliminates the check, and passes all tests.
