### PR TITLE
sun compiler (maybe others) doesn't like UTF-8 in the source

### DIFF
--- a/encengine.c
+++ b/encengine.c
@@ -81,7 +81,7 @@ This scheme can also handle shift encodings.
 
 A slight enhancement to the scheme also allows for look-ahead - if
 we add a flag to re-add the removed byte to the source we could handle
-  a" -> ä
+  a" -> U+00E4 (LATIN SMALL LETTER A WITH DIAERESIS)
   ab -> a (and take b back please)
 
 */


### PR DESCRIPTION
Maybe the comment should be something else again, but either way, the sun c compiler barfs (actaully the assembler) with unicode comment in the source.  This is the error:

```
cc -c  -I./Encode -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DPERL_USE_SAFE_PUTENV -O   -DVERSION=\"2.56\" -DXS_VERSION=\"2.56\" -KPIC "-I/home/ollisg/opt/perl/5.16.2/lib/5.16.2/i86pc-solaris/CORE"   encengine.c
Assembler: encengine.c
        "/tmp/ube.1388439226.6666.05.s", line 279 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 280 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 281 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 282 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 283 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 284 : Illegal character: <2f>
        "/tmp/ube.1388439226.6666.05.s", line 285 : Illegal character: <7b>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <7d>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal usage of '}'
        "/tmp/ube.1388439226.6666.05.s", line 288 : Syntax error
        Near line: "{       99  }       movl       %edx,-28(%ebp)               / sym=.CV0"
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <39>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <39>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <7b>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <7d>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal usage of '}'
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <39>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <39>
        "/tmp/ube.1388439226.6666.05.s", line 288 : Illegal character: <20>
Too many errors - Goodbye
cc: fbe failed for encengine.c
make: *** [encengine.o] Error 1
```
