### PR TITLE
[doc] clarify that CHECK coderefs return octets

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -801,12 +801,23 @@ If you're not interested in this, then bitwise-OR it with the bitmask.
 =head2 coderef for CHECK
 
 As of C<Encode> 2.12, C<CHECK> can also be a code reference which takes the
-ordinal value of the unmapped character as an argument and returns a string
-that represents the fallback character.  For instance:
+ordinal value of the unmapped character as an argument and returns
+octets that represent the fallback character.  For instance:
 
   $ascii = encode("ascii", $utf8, sub{ sprintf "<U+%04X>", shift });
 
 Acts like C<FB_PERLQQ> but U+I<XXXX> is used instead of C<\x{I<XXXX>}>.
+
+Even the fallback for C<decode> must return octets, which are
+then decoded with the character encoding that C<decode> accepts. So for
+example if you wish to decode octests as UTF-8, and use ISO-8859-15 as
+a fallback for bytes that are not valid UTF-8, you could write
+
+    $str = decode 'UTF-8', $octets, sub {
+        my $tmp = chr shift;
+        from_to $tmp, 'ISO-8859-15', 'UTF-8';
+        return $tmp;
+    };
 
 =head1 Defining Encodings
 


### PR DESCRIPTION
I would have intuitively expected that the fallback to decode()
should return a character string.
Since this has cost me several hours of debugging, I find it
appropriate to be more explicit in the docs.
