### PR TITLE
add PERL_NO_GET_CONTEXT to all dynamic libs

### DIFF
--- a/Byte/Makefile.PL
+++ b/Byte/Makefile.PL
@@ -102,6 +102,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/CN/Makefile.PL
+++ b/CN/Makefile.PL
@@ -78,6 +78,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/EBCDIC/Makefile.PL
+++ b/EBCDIC/Makefile.PL
@@ -59,6 +59,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/Encode.xs
+++ b/Encode.xs
@@ -19,8 +19,8 @@
    encode_method().  1 is recommended. 2 restores NI-S original */
 #define ENCODE_XS_USEFP   1
 
-#define UNIMPLEMENTED(x,y) y x (SV *sv, char *encoding) {dTHX;   \
-                         Perl_croak(aTHX_ "panic_unimplemented"); \
+#define UNIMPLEMENTED(x,y) y x (SV *sv, char *encoding) {		\
+			Perl_croak_nocontext("panic_unimplemented");	\
              return (y)0; /* fool picky compilers */ \
                          }
 /**/

--- a/JP/Makefile.PL
+++ b/JP/Makefile.PL
@@ -78,6 +78,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/KR/Makefile.PL
+++ b/KR/Makefile.PL
@@ -76,6 +76,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/Symbol/Makefile.PL
+++ b/Symbol/Makefile.PL
@@ -64,6 +64,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/TW/Makefile.PL
+++ b/TW/Makefile.PL
@@ -74,6 +74,7 @@ sub post_initialize
     $self->{'clean'}{'FILES'} .= join(' ',@files);
     open(XS,">$name.xs") || die "Cannot open $name.xs:$!";
     print XS <<'END';
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include <XSUB.h>

--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -184,6 +184,7 @@ END
 
   if ($cname =~ /(\w+)\.xs$/)
    {
+    print C "#define PERL_NO_GET_CONTEXT\n";
     print C "#include <EXTERN.h>\n";
     print C "#include <perl.h>\n";
     print C "#include <XSUB.h>\n";

--- a/encengine.c
+++ b/encengine.c
@@ -86,6 +86,7 @@ we add a flag to re-add the removed byte to the source we could handle
 
 */
 
+#define PERL_NO_GET_CONTEXT
 #include <EXTERN.h>
 #include <perl.h>
 #include "encode.h"


### PR DESCRIPTION
PERL_NO_GET_CONTEXT stops every perl function and macro from calling
Perl_get_context numerous times in threaded Perl builds. This makes
loading time and BOOT: xsub faster by removing many function calls and
machine code. Changing UNIMPLEMENTED removed the last reference to
Perl_get_context from every shared library in Encode on a threaded build.
