### PR TITLE
Validate continuations in the incremental UTF-X decoder

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -343,10 +343,14 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
         if (UTF8_IS_START(*s)) {
             U8 skip = UTF8SKIP(s);
             if ((s + skip) > e) {
-                /* Partial character */
-                /* XXX could check that rest of bytes are UTF8_IS_CONTINUATION(ch) */
-                if (stop_at_partial || (check & ENCODE_STOP_AT_PARTIAL))
+                if (stop_at_partial || (check & ENCODE_STOP_AT_PARTIAL)) {
+                    const U8 *p = s + 1;
+                    for (; p < e; p++) {
+                        if (!UTF8_IS_CONTINUATION(*p))
+                            goto malformed_byte;
+                    }
                     break;
+                }
 
                 goto malformed_byte;
             }


### PR DESCRIPTION
Ensure that the prefix octet is followed by continuation octets in the case of a partial UTF-X sequence.
