### PR TITLE
maintain taint flag when encoding MIME on old perl

### DIFF
--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -139,7 +139,7 @@ sub encode($$;$) {
         push @line, join( "\n " => @subline );
     }
     $_[1] = '' if $chk;
-    return join( "\n", @line );
+    return (substr($str, 0, 0) . join( "\n", @line ));
 }
 
 use constant HEAD   => '=?UTF-8?';

--- a/t/taint.t
+++ b/t/taint.t
@@ -3,7 +3,8 @@ use strict;
 use Encode qw(encode decode);
 use Scalar::Util qw(tainted);
 use Test::More;
-my $str = "dan\x{5f3e}" . substr($ENV{PATH},0,0); # tainted string to encode
+my $taint = substr($ENV{PATH},0,0);
+my $str = "dan\x{5f3e}" . $taint;                 # tainted string to encode
 my $bin = encode('UTF-8', $str);                  # tainted binary to decode
 my @names = Encode->encodings(':all');
 plan tests => 2 * @names;
@@ -16,7 +17,7 @@ for my $name (@names) {
       skip $@, 1 if $@;
       ok tainted($e), "encode $name";
     }
-    $bin = $e if $e;
+    $bin = $e.$taint if $e;
     eval {
         $d = decode($name, $bin);
     };


### PR DESCRIPTION
On perl 5.8.8 and below, loading utf8_heavy.pl (which happens implictly
in many places) will cause a split using a character class to not
maintain the taint flag.  Since the MIME header encoding reconstructs
the string after splitting it, we need to explicitly copy the taint flag
using a substr($s, 0, 0).

Also includes a small test adjustment I used to track this down.