### PR TITLE
Fix C++ build on Windows with VC++

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -7,6 +7,7 @@
 #include "perl.h"
 #include "XSUB.h"
 #include "encode.h"
+#include "def_t.h"
 
 # define PERLIO_MODNAME  "PerlIO::encoding"
 # define PERLIO_FILENAME "PerlIO/encoding.pm"
@@ -1002,6 +1003,5 @@ OUTPUT:
 
 BOOT:
 {
-#include "def_t.h"
 #include "def_t.exh"
 }

--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -280,8 +280,9 @@ if ($doC)
     # push(@{$encoding{$name}},outstring(\*C,$e2u->{Cname}.'_def',$erep));
    }
   my $cpp = ($Config{d_cplusplus} || '') eq 'define';
-  my $exta = $cpp ? 'extern "C" ' : "static";
-  my $extb = $cpp ? 'extern "C" ' : "";
+  my $ext  = $cpp ? 'extern "C"' : "extern";
+  my $exta = $cpp ? 'extern "C"' : "static";
+  my $extb = $cpp ? 'extern "C"' : "";
   foreach my $enc (sort cmp_name keys %encoding)
    {
     # my ($e2u,$u2e,$rep,$min_el,$max_el,$rsym) = @{$encoding{$enc}};
@@ -308,7 +309,7 @@ if ($doC)
    {
     my $sym = "${enc}_encoding";
     $sym =~ s/\W+/_/g;
-    print H "extern encode_t $sym;\n";
+    print H "${ext} encode_t $sym;\n";
     print D " Encode_XSEncoding(aTHX_ &$sym);\n";
    }
 


### PR DESCRIPTION
NOTE: This PR will fix https://rt.cpan.org/Ticket/Display.html?id=82897

The change to enc2xs follows from this thread:
http://www.nntp.perl.org/group/perl.perl5.porters/2015/01/msg224875.html

The change to Encode.xs is to fix errors in the Encode.c compilation
which results from the enc2xs change (now that we specify "C" linkage, the
header file cannot be #included within { }):
c:\dev\git\perl\cpan\encode\def_t.h(7) : error C2598: linkage specification must be at global scope
c:\dev\git\perl\cpan\encode\def_t.h(7) : error C2512: 'encode_s' : no appropriate default constructor available
c:\dev\git\perl\cpan\encode\def_t.h(8) : error C2598: linkage specification must be at global scope
c:\dev\git\perl\cpan\encode\def_t.h(8) : error C2512: 'encode_s' : no appropriate default constructor available
c:\dev\git\perl\cpan\encode\def_t.h(9) : error C2598: linkage specification must be at global scope
c:\dev\git\perl\cpan\encode\def_t.h(9) : error C2512: 'encode_s' : no appropriate default constructor available
c:\dev\git\perl\cpan\encode\def_t.h(10) : error C2598: linkage specification must be at global scope
c:\dev\git\perl\cpan\encode\def_t.h(10) : error C2512: 'encode_s' : no appropriate default constructor available