### PR TITLE
Bump $VERSION in module changed since Encode-2.60

### DIFF
--- a/Unicode/Unicode.pm
+++ b/Unicode/Unicode.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 no warnings 'redefine';
 
-our $VERSION = do { my @r = ( q$Revision: 2.9 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
+our $VERSION = do { my @r = ( q$Revision: 2.10 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 
 use XSLoader;
 XSLoader::load( __PACKAGE__, $VERSION );


### PR DESCRIPTION
This $VERSION bump is necessary to keep bleadperl's
Porting/cmpVERSION.pl script happy when comparing current blead against
perl-5.20.1. blead has Encode-2.68; 5.20.1 has Encode-2.60. This module has
changed (in its XS file *), but its $VERSION number has not.

(*) It's a tiny, insignicificant change--not even a change in
documentation, let alone in functionality--but the cmpVERSION.pl script
doesn't understand that. It simply requires that different versions of a
file have different $VERSION numbers.