### PR TITLE
gitignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,24 @@ Thumbs.db
 attic/**/*
 node_modules/**/*
 tmp/**/*
+
+# Build artifacts
+Byte/
+CN/
+EBCDIC/
+Encode.bs
+Encode.c
+JP/
+KR/
+MYMETA.json
+MYMETA.yml
+Makefile
+Symbol/
+TW/
+Unicode/
+blib/
+def_t.c
+def_t.exh
+def_t.fnm
+def_t.h
+pm_to_blib


### PR DESCRIPTION
Currently, git users have to remember to avoid accidentally checking in files generated by make. I've added a basic list of these file patterns to our `.gitignore`.

In the future, we should probably build all artifacts into a `target/` directory or similar.