### PR TITLE
Encode::encoding: Don't fail 'no encoding' on EBCDIC

### DIFF
--- a/encoding.pm
+++ b/encoding.pm
@@ -8,13 +8,6 @@ use warnings;
 
 use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
 
-BEGIN {
-    if ( ord("A") == 193 ) {
-        require Carp;
-        Carp::croak("encoding: pragma does not support EBCDIC platforms");
-    }
-}
-
 our $HAS_PERLIO = 0;
 eval { require PerlIO::encoding };
 unless ($@) {
@@ -102,6 +95,11 @@ sub _get_locale_encoding {
 }
 
 sub import {
+    if ( ord("A") == 193 ) {
+        require Carp;
+        Carp::croak("encoding: pragma does not support EBCDIC platforms");
+    }
+
     if ($] >= 5.017) {
 	warnings::warnif("deprecated",
 			 "Use of the encoding pragma is deprecated")


### PR DESCRIPTION
On an EBCDIC platform, if someone specifies 'no encoding' it croaks at
compile time.  But it isn't a problem to specify 'no encoding'.  It is
only a problem to specify 'use encoding'.  So move the test to the
import function.