### PR TITLE
encoding.pm: more inlining

### DIFF
--- a/encoding.pm
+++ b/encoding.pm
@@ -6,19 +6,16 @@ use Encode;
 use strict;
 use warnings;
 
-use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
+use constant {
+    DEBUG => !!$ENV{PERL_ENCODE_DEBUG},
+    HAS_PERLIO => eval { require PerlIO::encoding; PerlIO::encoding->VERSION(0.02) },
+};
 
 BEGIN {
     if ( ord("A") == 193 ) {
         require Carp;
         Carp::croak("encoding: pragma does not support EBCDIC platforms");
     }
-}
-
-our $HAS_PERLIO = 0;
-eval { require PerlIO::encoding };
-unless ($@) {
-    $HAS_PERLIO = ( PerlIO::encoding->VERSION >= 0.02 );
 }
 
 sub _exception {
@@ -143,7 +140,7 @@ sub import {
                 ${^E_NCODING} = $enc;
             }
         }
-        $HAS_PERLIO or return 1;
+        HAS_PERLIO or return 1;
     }
     else {
         defined( ${^ENCODING} ) and undef ${^ENCODING};
@@ -198,7 +195,7 @@ sub unimport {
     no warnings;
     undef ${^ENCODING};
     undef ${^E_NCODING} if $^V && $^V ge v5.21.7;
-    if ($HAS_PERLIO) {
+    if (HAS_PERLIO) {
         binmode( STDIN,  ":raw" );
         binmode( STDOUT, ":raw" );
     }

--- a/encoding.pm
+++ b/encoding.pm
@@ -9,6 +9,7 @@ use warnings;
 use constant {
     DEBUG => !!$ENV{PERL_ENCODE_DEBUG},
     HAS_PERLIO => eval { require PerlIO::encoding; PerlIO::encoding->VERSION(0.02) },
+    PERL_5_21_7 => $^V && $^V ge v5.21.7,
 };
 
 BEGIN {
@@ -129,7 +130,7 @@ sub import {
     unless ( $arg{Filter} ) {
         DEBUG and warn "_exception($name) = ", _exception($name);
         if (! _exception($name)) {
-            if (!$^V || $^V lt v5.21.7) {
+            if (!PERL_5_21_7) {
                 ${^ENCODING} = $enc;
             }
             else {
@@ -144,7 +145,7 @@ sub import {
     }
     else {
         defined( ${^ENCODING} ) and undef ${^ENCODING};
-        undef ${^E_NCODING} if $^V && $^V ge v5.21.7;
+        undef ${^E_NCODING} if PERL_5_21_7;
 
         # implicitly 'use utf8'
         require utf8;      # to fetch $utf8::hint_bits;
@@ -194,7 +195,7 @@ sub import {
 sub unimport {
     no warnings;
     undef ${^ENCODING};
-    undef ${^E_NCODING} if $^V && $^V ge v5.21.7;
+    undef ${^E_NCODING} if PERL_5_21_7;
     if (HAS_PERLIO) {
         binmode( STDIN,  ":raw" );
         binmode( STDOUT, ":raw" );


### PR DESCRIPTION
Move some checks as constants to allow perl to inline more at cxompile time:
- HAS_PERLIO check
- perl 5.21.7 check