### PR TITLE
Fix 0x95

### DIFF
--- a/ucm/koi8-u.ucm
+++ b/ucm/koi8-u.ucm
@@ -5,7 +5,7 @@
 # ./compile -n koi8-u -o Encode/koi8-u.ucm Encode/koi8-u.enc
 #
 # Original table can be obtained at
-# http://www.unicode.org/Public/MAPPINGS/VENDORS/MISC/KOI8-R.TXT
+# http://www.unicode.org/Public/MAPPINGS/VENDORS/MISC/KOI8-U.TXT
 #
 #       Copyright (c) 1991-2008 Unicode, Inc.  All Rights reserved.
 #
@@ -178,7 +178,7 @@ CHARMAP
 <U2593> \x92 |0 # DARK SHADE
 <U2320> \x93 |0 # TOP HALF INTEGRAL
 <U25A0> \x94 |0 # BLACK SQUARE
-<U2022> \x95 |0 # BULLET
+<U2219> \x95 |0 # BULLET OPERATOR
 <U221A> \x96 |0 # SQUARE ROOT
 <U2248> \x97 |0 # ALMOST EQUAL TO
 <U2264> \x98 |0 # LESS-THAN OR EQUAL TO


### PR DESCRIPTION
Both http://www.unicode.org/Public/MAPPINGS/VENDORS/MISC/KOI8-U.TXT
and RFC2319 provide "BULLET OPERATOR" instead of "BULLET" for 0x95.

Also, fix URL in header comment.