### PR TITLE
remove extra space when folding

### DIFF
--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -136,7 +136,7 @@ sub encode($$;$) {
             $subline .= $word;
         }
         length($subline) and push @subline, $subline;
-        push @line, join( "\n " => @subline );
+        push @line, join( "\n" => @subline );
     }
     $_[1] = '' if $chk;
     return (substr($str, 0, 0) . join( "\n", @line ));


### PR DESCRIPTION
Folding in the encode function prepends an extra space to the new line. For example, the following:

```
use feature qw(say);
use Encode qw/encode decode/;

$string = 'I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"m Time Mime';
$string = encode('MIME-Header', $string);

say $string;
```

Returns:
```
I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"
 m Time Mime I\"m Time Mime
```

When it should return:
```
I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"m Time Mime I\"
m Time Mime I\"m Time Mime
```