### PR TITLE
MANIFEST: add missing t/encoding-locale.t

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -76,6 +76,7 @@ t/enc_module.enc test data for t/enc_module.t
 t/enc_module.t	test script
 t/enc_utf8.t	test script
 t/encoding.t	test script
+t/encoding-locale.t  test script
 t/fallback.t	test script
 t/from_to.t	test script
 t/gb2312.enc	test data


### PR DESCRIPTION
In #40 I had submitted a new test file, `t/encoding-locale.t`. Unfortunately I did not notice that MANIFEST had to be manually updated. So this test never reached CPAN.

Let's push it to the world!