### PR TITLE
Update Alias.pm

### DIFF
--- a/lib/Encode/Alias.pm
+++ b/lib/Encode/Alias.pm
@@ -139,7 +139,7 @@ sub init_aliases {
     define_alias( qr/^UCS-?2-?LE$/i => '"UCS-2LE"' );
     define_alias(
         qr/^UCS-?2-?(BE)?$/i    => '"UCS-2BE"',
-        qr/^UCS-?4-?(BE|LE)?$/i => 'uc("UTF-32$1")',
+        qr/^UCS-?4-?(BE|LE|)?$/i => 'uc("UTF-32$1")',
         qr/^iso-10646-1$/i      => '"UCS-2BE"'
     );
     define_alias(


### PR DESCRIPTION
Added "|" after "(BE|LE" on line 142 (UCS-4 to UTF-32 alias) to prevent "Use of uninitialized value $1 in concatenation (.) or string" warning.