### PR TITLE
Fix the encoding-locale test to skip properly if _get_locale_encoding returns undef

### DIFF
--- a/t/encoding-locale.t
+++ b/t/encoding-locale.t
@@ -14,8 +14,9 @@ use Encode qw<find_encoding>;
 my $locale_encoding = encoding::_get_locale_encoding;
 
 SKIP: {
-    is(ref $locale_encoding, '', '_get_locale_encoding returns a scalar value')
-	or skip 'no locale encoding found', 1;
+    defined $locale_encoding or skip 'no locale encoding found', 3;
+
+    is(ref $locale_encoding, '', '_get_locale_encoding returns a scalar value');
 
     my $enc = find_encoding($locale_encoding);
     ok(defined $enc, 'encoding returned is supported')


### PR DESCRIPTION
On our HP-UX systems, _get_locale_encoding returns undef. This caused the encoding-locale test to fail with the following output:

```1..3
ok 1 - _get_locale_encoding returns a scalar value
Use of uninitialized value $name in substitution (s///) at blib/lib/Encode.pm line 103.
Use of uninitialized value $name in exists at blib/lib/Encode.pm line 106.
Use of uninitialized value $name in lc at blib/lib/Encode.pm line 107.
Use of uninitialized value $find in exists at blib/lib/Encode/Alias.pm line 25.
Use of uninitialized value $find in hash element at blib/lib/Encode/Alias.pm line 26.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 40.
Use of uninitialized value $find in pattern match (m//) at blib/lib/Encode/Alias.pm line 31.
Use of uninitialized value $find in string eq at blib/lib/Encode/Alias.pm line 44.
Use of uninitialized value $find in hash element at blib/lib/Encode/Alias.pm line 57.
Use of uninitialized value $find in lc at blib/lib/Encode/Alias.pm line 58.
Use of uninitialized value $find in hash element at blib/lib/Encode/Alias.pm line 77.
Use of uninitialized value $name in string ne at blib/lib/Encode.pm line 112.
Use of uninitialized value $name in hash element at blib/lib/Encode.pm line 116.
not ok 2 - encoding returned is supported
#   Failed test 'encoding returned is supported'
#   at t/encoding-locale.t line 21.
# Encoding: undef
not ok 3 - undef isa 'Encode::Encoding'
#   Failed test 'undef isa 'Encode::Encoding''
#   at t/encoding-locale.t line 23.
#     undef isn't defined
Can't call method "name" on an undefined value at t/encoding-locale.t line 24.
# Looks like you failed 2 tests of 3.
# Looks like your test exited with 255 just after 3.
```