### PR TITLE
t/encoding-locale.t fails with Test::More@0.80 or before.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,6 +51,9 @@ WriteMakefile(
         Exporter   => '5.57',   # use Exporter 'import';
 	parent     => '0.221',  # version bundled with 5.10.1
     },
+    TEST_REQUIRES => {
+        'Test::More' => '0.81_01',
+    },
     PMLIBDIRS   => \@pmlibdirs,
     INSTALLDIRS => ($] < 5.011 ? 'perl' : 'site'),
     META_MERGE        => {


### PR DESCRIPTION
Environment:
* Perl 5.8.8 and Test::More@0.62

Error message:
```
...
t/encoding-locale..........Undefined subroutine &main::note called at t/encoding-locale.t line 25.
# Looks like your test died just after 3.
dubious
        Test returned status 255 (wstat 65280, 0xff00)
        after all the subtests completed successfully
...
```

Test::More@0.80 or before does not have note() method.
https://metacpan.org/changes/distribution/Test-Simple
```
...
0.81_01  Sat Sep  6 15:13:50 PDT 2008
    New Features
    * Adam Kennedy bribed me to add new_ok().  The price was one DEFCON license key.
      [rt.cpan.org 8891]
    * TODO tests can now start and end with 'todo_start' and 'todo_end'
      Test::Builder methods. [rt.cpan.org 38018]
    * Added Test::Builder->in_todo() for a safe way to check if a test is inside a
      TODO block.  This allows TODO tests with no reason.
    * Added note() and explain() to both Test::More and Test::Builder.
      [rt.cpan.org 14764] [test-more.googlecode.com 3]
 
    Feature Changes
    * Changed the message for extra tests run to show the number of tests run rather than
      the number extra to avoid the user having to do mental math.
      [rt.cpan.org 7022]   
 
    Bug fixes
    - using a relative path to perl broke tests              [rt.cpan.org 34050]
    - use_ok() broke $SIG{__DIE__} in the used module        [rt.cpan.org 34065]
    - diagnostics for isnt() were confusing on failure       [rt.cpan.org 33642]
    - warnings when MakeMaker's version contained _          [rt.cpan.org 33626]
    - add explicit test that non-integer plans die correctly [rt.cpan.org 28836]
      (Thanks to Hans Dieter Pearcey [confound] for fixing the above)
    - die if no_plan is given an argument                    [rt.cpan.org 27429]
 
 
0.80  Sun Apr  6 17:25:01 CEST 2008
    Test fixes
    - Completely disable the utf8 test.  It was causing perl to panic on some OS's.
...
```