### PR TITLE
Rethrow 'utf8' warnings in from_to as well

### DIFF
--- a/t/utf8warnings.t
+++ b/t/utf8warnings.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use Encode;
-use Test::More tests => 7;
+use Test::More tests => 10;
 
 my $valid   = "\x61\x00\x00\x00";
 my $invalid = "\x78\x56\x34\x12";
@@ -23,6 +23,8 @@ my $enc = find_encoding("UTF32-LE");
     my $ret = Encode::Unicode::decode( $enc, $valid );
     is("@warnings", "", "Calling decode in Encode::Unicode on valid string produces no warnings");
 }
+
+
 
 {
     @warnings = ();
@@ -44,6 +46,8 @@ my $enc = find_encoding("UTF32-LE");
     is("@warnings", "", "Warning from decode in Encode::Unicode can be silenced via no warnings");
 }
 
+
+
 {
     @warnings = ();
     my $ret = Encode::decode( $enc, $invalid );
@@ -61,6 +65,30 @@ my $enc = find_encoding("UTF32-LE");
     no warnings;
     @warnings = ();
     my $ret = Encode::decode( $enc, $invalid );
-    is("@warnings", "", "Warning from decode in Encode can be silenced via no warnings 'utf8'");
+    is("@warnings", "", "Warning from decode in Encode can be silenced via no warnings");
 };
 
+
+
+{
+    @warnings = ();
+    my $inplace = $invalid;
+    Encode::from_to( $inplace, "UTF32-LE", "UTF-8" );
+    like("@warnings", qr/is not Unicode/, "Calling from_to in Encode on invalid string warns");
+}
+
+{
+    no warnings 'utf8';
+    @warnings = ();
+    my $inplace = $invalid;
+    Encode::from_to( $inplace, "UTF32-LE", "UTF-8" );
+    is("@warnings", "", "Warning from from_to in Encode can be silenced via no warnings 'utf8'");
+};
+
+{
+    no warnings;
+    @warnings = ();
+    my $inplace = $invalid;
+    Encode::from_to( $inplace, "UTF32-LE", "UTF-8" );
+    is("@warnings", "", "Warning from from_to in Encode can be silenced via no warnings");
+};


### PR DESCRIPTION
This applies the same changes in a6c2ba38 (pull #26) to the `from_to`
method as well.