### PR TITLE
CVE-2016-1238: avoid loading optional modules from .

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -56,6 +56,8 @@ require Encode::Config;
 eval {
     local $SIG{__DIE__};
     local $SIG{__WARN__};
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     require Encode::ConfigLocal;
 };
 

--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -4,6 +4,7 @@ BEGIN {
     # with $ENV{PERL_CORE} set
     # In case we need it in future...
     require Config; import Config;
+    pop @INC if $INC[-1] eq '.';
 }
 use strict;
 use warnings;

--- a/bin/encguess
+++ b/bin/encguess
@@ -1,5 +1,6 @@
 #!./perl
 use 5.008001;
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use warnings;
 use Encode;

--- a/bin/piconv
+++ b/bin/piconv
@@ -1,6 +1,7 @@
 #!./perl
 # $Id: piconv,v 2.7 2014/05/31 09:48:48 dankogai Exp $
 #
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use 5.8.0;
 use strict;
 use Encode ;

--- a/bin/ucmlint
+++ b/bin/ucmlint
@@ -3,6 +3,7 @@
 # $Id: ucmlint,v 2.2 2008/03/12 09:51:11 dankogai Exp $
 #
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 our  $VERSION = do { my @r = (q$Revision: 2.2 $ =~ /\d+/g); sprintf "%d."."%02d" x $#r, @r };
 

--- a/bin/unidump
+++ b/bin/unidump
@@ -1,5 +1,6 @@
 #!./perl
 
+BEGIN { pop @INC if $INC[-1] eq '.' }
 use strict;
 use Encode;
 use Getopt::Std;


### PR DESCRIPTION
The change to Encode.pm is the most critical part of this patch.

Without this change, and process that uses Encode started with a
current directory that's world writable (such as /tmp) and if there's
no global Encode::ConfigLocal, can be attacked by another user
by creating /tmp/Encode/ConfigLocal.pm

It's possible most of the tools changed here do not need to be updated,
but I chose a conservative path.