### PR TITLE
Fixes for 5.8.x compilation failures

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -482,6 +482,10 @@ MODULE = Encode		PACKAGE = Encode::utf8	PREFIX = Method_
 
 PROTOTYPES: DISABLE
 
+#ifndef SvIsCOW
+# define SvIsCOW(sv) (SvREADONLY(sv) && SvFAKE(sv))
+#endif
+
 void
 Method_decode_xs(obj,src,check_sv = &PL_sv_no)
 SV *	obj
@@ -718,6 +722,17 @@ CODE:
     XSRETURN(1);
 }
 
+
+#ifndef SvPV_force_nolen
+#   define SvPV_force_nolen(sv) SvPV_force_flags_nolen(sv, SV_GMAGIC)
+#endif
+
+#ifndef SvPV_force_flags_nolen
+#   define SvPV_force_flags_nolen(sv, flags) \
+        ((SvFLAGS(sv) & (SVf_POK|SVf_THINKFIRST)) == SVf_POK \
+        ? SvPVX(sv) : sv_pvn_force_flags(sv, &PL_na, flags))
+#endif
+
 void
 Method_encode(obj,src,check_sv = &PL_sv_no)
 SV *	obj
@@ -928,10 +943,6 @@ CODE:
 }
 OUTPUT:
     RETVAL
-
-#ifndef SvIsCOW
-# define SvIsCOW(sv) (SvREADONLY(sv) && SvFAKE(sv))
-#endif
 
 SV *
 _utf8_on(sv)

--- a/encoding.pm
+++ b/encoding.pm
@@ -155,7 +155,9 @@ sub import {
                 ${^E_NCODING} = $enc;
             }
         }
-        HAS_PERLIO or return 1;
+        if (! HAS_PERLIO ) {
+            return 1;
+        }
     }
     else {
         defined( ${^ENCODING} ) and undef ${^ENCODING};


### PR DESCRIPTION
These changes are sufficient for me to get things rolling on older perls. I **have not** used `Devel::PPPort` as it does not seem to work cleanly (likely conflicts with preexisting macro definitions deep in `Encode`'s source, perhaps something @wolfsage can answer better).

The PR is the best I can do given my current know-how, feel free to reject it and implement something better!

Cheers