### PR TITLE
Fix return value of Encode::encode_utf8(undef)

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -254,6 +254,7 @@ sub from_to($$$;$) {
 
 sub encode_utf8($) {
     my ($str) = @_;
+    return undef unless defined $str;
     utf8::encode($str);
     return $str;
 }

--- a/t/utf8ref.t
+++ b/t/utf8ref.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use Encode;
 use Test::More;
-plan tests => 4;
+plan tests => 12;
 #plan 'no_plan';
 
 # my $a = find_encoding('ASCII');
@@ -18,3 +18,16 @@ is $u->encode($r), '';
 $r = {};
 is decode_utf8($r), ''.$r;
 is $u->decode($r), '';
+use warnings 'uninitialized';
+
+is encode_utf8(undef), undef;
+is decode_utf8(undef), undef;
+
+is encode_utf8(''), '';
+is decode_utf8(''), '';
+
+is Encode::encode('utf8', undef), undef;
+is Encode::decode('utf8', undef), undef;
+
+is Encode::encode('utf8', ''), '';
+is Encode::decode('utf8', ''), '';


### PR DESCRIPTION
Documentation says that '$octets = encode_utf8($string)' is equivalent to
'$octets = encode("utf8", $string)'. And if the $string is undef, then
undef is returned. However without this patch encode_utf8(undef) returned
'' (empty string) and not undef. This patch fixes it and undef is returned.

All other utf8 Encode calls already returns undef, just encode_utf8() acted
differently.

  Encode::encode('utf8', undef) -> undef
  Encode::decode('utf8', undef) -> undef
  Encode::decode_utf8(undef) -> undef

Reported bug: https://rt.cpan.org/Public/Bug/Display.html?id=116904