### PR TITLE
Encode::utf8: Fix count of replacement characters for overflowed and overlong UTF-8 sequences

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -366,8 +366,10 @@ convert_utf8_multi_seq(U8* s, STRLEN len, STRLEN *rlen)
 
     *rlen = s-ptr;
 
-    if (overflowed || *rlen > (STRLEN)UNISKIP(uv))
+    if (overflowed || *rlen > (STRLEN)UNISKIP(uv)) {
+        *rlen = 1;
         return 0;
+    }
 
     return uv;
 }


### PR DESCRIPTION
This revert back previous behavior. See comment: https://github.com/dankogai/p5-encode/issues/64#issuecomment-240656967