### PR TITLE
Fix panic when encoding undef scalars

### DIFF
--- a/lib/Encode/Encoder.pm
+++ b/lib/Encode/Encoder.pm
@@ -85,7 +85,9 @@ sub AUTOLOAD {
         from_to( $self->{data}, $self->{encoding}, $obj->name, 1 );
     }
     else {
-        $self->{data} = $obj->encode( $self->{data}, 1 );
+        if ( defined($self->{data}) ) {
+            $self->{data} = $obj->encode( $self->{data}, 1 );
+        }
     }
     $self->{encoding} = $obj->name;
     return $self;

--- a/t/undef.t
+++ b/t/undef.t
@@ -1,0 +1,8 @@
+use Encode::Encoder qw(encoder);
+
+use Test::More;
+plan tests => 1;
+
+my $emptyutf8;
+eval { $c = encoder($emptyutf8)->utf8; };
+ok(!$@,"crashed encoding undef variable ($@)");


### PR DESCRIPTION
This pull request will fix the "panic: sv_setpvn called with negative strlen at /usr/lib/perl5/5.8.8/i386-linux-thread-multi/Encode/Encoder.pm line 84" error, when you will try to Encoder::encode a undefined scalar. See also the accompanied unit test (t/undef.t).