### PR TITLE
Fix crash caused by undefined behaviour between two sequence points

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -102,6 +102,7 @@ t/perlio.t	test script
 t/piconv.t	test script
 t/rt.pl		even more test script
 t/rt85489.t	test script
+t/rt113164.t	test script
 t/taint.t       test script
 t/unibench.pl	benchmark script
 t/utf8ref.t	test script

--- a/t/rt113164.t
+++ b/t/rt113164.t
@@ -1,0 +1,38 @@
+BEGIN {
+    if ($ENV{'PERL_CORE'}) {
+        chdir 't';
+        unshift @INC, '../lib';
+    }
+    require Config; import Config;
+    if ($Config{'extensions'} !~ /\bEncode\b/) {
+      print "1..0 # Skip: Encode was not built\n";
+      exit 0;
+    }
+    if (ord("A") == 193) {
+      print "1..0 # Skip: EBCDIC\n";
+      exit 0;
+    }
+    $| = 1;
+}
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Encode;
+
+my $str = "You" . chr(8217) . "re doomed!";
+
+my $data;
+
+my $cb = sub {
+    $data = [ ('?') x 12_500 ];
+    return ";";
+};
+
+my $octets = encode('iso-8859-1', $str, $cb);
+is $octets, "You;re doomed!", "stack was not overwritten";
+
+$octets = encode('iso-8859-1', $str, $cb);
+is $octets, "You;re doomed!", "stack was not overwritten";


### PR DESCRIPTION
Construction like this:

ST(0) = encode_method(aTHX_ enc, enc->f_utf8, src, check, NULL, Nullsv, NULL, fallback_cb);

with src = ST(1) and fallback_cb as subroutine which reallocate perl stack
leads to undefined behaviour when pointers to perl stack variables are
modified more times between two sequence points.

When that code is compiled under gcc 4.6 then at first is evaluated pointer
for ST(0), second is evaluation of encode_method() function and third is
assignment of return value. But encode_method() modified pointers to perl
stack variables and old pointer for ST(0) from first step does not have to
be correct...

With this patch ST(0) is not directly modified between two sequence points
but via temporary variable RETVAL. Tested under valgrind that memory
corruption disappeared.

Fixes bug: https://rt.cpan.org/Public/Bug/Display.html?id=113164