### PR TITLE
Disable _utf8_on and _utf8_off for tainted values

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -986,7 +986,7 @@ SV *	sv
 CODE:
 {
     SvGETMAGIC(sv);
-    if (SvPOKp(sv)) {
+    if (!SvTAINTED(sv) && SvPOKp(sv)) {
         if (SvTHINKFIRST(sv)) sv_force_normal(sv);
         RETVAL = newSViv(SvUTF8(sv));
         SvUTF8_on(sv);
@@ -1004,7 +1004,7 @@ SV *	sv
 CODE:
 {
     SvGETMAGIC(sv);
-    if (SvPOKp(sv)) {
+    if (!SvTAINTED(sv) && SvPOKp(sv)) {
         if (SvTHINKFIRST(sv)) sv_force_normal(sv);
         RETVAL = newSViv(SvUTF8(sv));
         SvUTF8_off(sv);

--- a/t/taint.t
+++ b/t/taint.t
@@ -10,7 +10,7 @@ my $notaint = "";
 my $notaint_str = "dan\x{5f3e}" . $notaint;
 my $notaint_bin = encode('UTF-8', $notaint_str);
 my @names = Encode->encodings(':all');
-plan tests => 4 * @names;
+plan tests => 4 * @names + 2;
 for my $name (@names) {
     my ($d, $e, $s);
     eval {
@@ -47,3 +47,7 @@ for my $name (@names) {
       ok ! tainted($d), "decode $name";
     }
 }
+Encode::_utf8_on($bin);
+ok(!Encode::is_utf8($bin), "Encode::_utf8_on does not work on tainted values");
+Encode::_utf8_off($str);
+ok(Encode::is_utf8($str), "Encode::_utf8_off does not work on tainted values");


### PR DESCRIPTION
Encode documentation says:
For security reasons, this function does not work on tainted values.