### PR TITLE
Do not use expressions in macros SvTRUE, SvPV, SvIV, attr and attr_true

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -832,6 +832,8 @@ CODE:
 void
 Method_perlio_ok(obj)
 SV *	obj
+PREINIT:
+    SV *sv;
 CODE:
 {
     /* encode_t *enc = INT2PTR(encode_t *, SvIV(SvRV(obj))); */
@@ -841,7 +843,8 @@ CODE:
     eval_pv("require PerlIO::encoding", 0);
     SPAGAIN;
 
-    if (SvTRUE(get_sv("@", 0))) {
+    sv = get_sv("@", 0);
+    if (SvTRUE(sv)) {
     ST(0) = &PL_sv_no;
     }else{
     ST(0) = &PL_sv_yes;
@@ -852,6 +855,8 @@ CODE:
 void
 Method_mime_name(obj)
 SV *	obj
+PREINIT:
+    SV *sv;
 CODE:
 {
     encode_t *enc = INT2PTR(encode_t *, SvIV(SvRV(obj)));
@@ -859,7 +864,8 @@ CODE:
     eval_pv("require Encode::MIME::Name", 0);
     SPAGAIN;
 
-    if (SvTRUE(get_sv("@", 0))) {
+    sv = get_sv("@", 0);
+    if (SvTRUE(sv)) {
 	ST(0) = &PL_sv_undef;
     }else{
 	ENTER;

--- a/Unicode/Unicode.xs
+++ b/Unicode/Unicode.xs
@@ -125,8 +125,6 @@ PROTOTYPES: DISABLE
 
 #define attr(k, l)  (hv_exists((HV *)SvRV(obj),k,l) ? \
     *hv_fetch((HV *)SvRV(obj),k,l,0) : &PL_sv_undef)
-#define attr_true(k, l)  (hv_exists((HV *)SvRV(obj),k,l) ? \
-    SvTRUE(*hv_fetch((HV *)SvRV(obj),k,l,0)) : FALSE)
 
 void
 decode_xs(obj, str, check = 0)
@@ -135,8 +133,10 @@ SV *	str
 IV	check
 CODE:
 {
-    U8 endian    = *((U8 *)SvPV_nolen(attr("endian", 6)));
-    int size     = SvIV(attr("size", 4));
+    SV *sve      = attr("endian", 6);
+    U8 endian    = *((U8 *)SvPV_nolen(sve));
+    SV *svs      = attr("size", 4);
+    int size     = SvIV(svs);
     int ucs2     = -1; /* only needed in the event of surrogate pairs */
     SV *result   = newSVpvn("",0);
     STRLEN usize = (size > 0 ? size : 1); /* protect against rogue size<=0 */
@@ -155,6 +155,7 @@ CODE:
     SvUTF8_on(result);
 
     if (!endian && s+size <= e) {
+	SV *sv;
 	UV bom;
 	endian = (size == 4) ? 'N' : 'n';
 	bom = enc_unpack(aTHX_ &s,e,size,endian);
@@ -183,7 +184,8 @@ CODE:
 	}
 #if 1
 	/* Update endian for next sequence */
-	if (attr_true("renewed", 7)) {
+	sv = attr("renewed", 7);
+	if (SvTRUE(sv)) {
 	    (void)hv_store((HV *)SvRV(obj),"endian",6,newSVpv((char *)&endian,1),0);
 	}
 #endif
@@ -202,7 +204,8 @@ CODE:
 	U8 *d;
 	if (issurrogate(ord)) {
 	    if (ucs2 == -1) {
-		ucs2 = attr_true("ucs2", 4);
+		SV *sv = attr("ucs2", 4);
+		ucs2 = SvTRUE(sv);
 	    }
 	    if (ucs2 || size == 4) {
 		if (check) {
@@ -322,8 +325,10 @@ SV *	utf8
 IV	check
 CODE:
 {
-    U8 endian = *((U8 *)SvPV_nolen(attr("endian", 6)));
-    const int size = SvIV(attr("size", 4));
+    SV *sve = attr("endian", 6);
+    U8 endian = *((U8 *)SvPV_nolen(sve));
+    SV *svs = attr("size", 4);
+    const int size = SvIV(svs);
     int ucs2 = -1; /* only needed if there is invalid_ucs2 input */
     const STRLEN usize = (size > 0 ? size : 1);
     SV *result = newSVpvn("", 0);
@@ -344,11 +349,13 @@ CODE:
     SvGROW(result, ((ulen+1) * usize));
 
     if (!endian) {
+	SV *sv;
 	endian = (size == 4) ? 'N' : 'n';
 	enc_pack(aTHX_ result,size,endian,BOM_BE);
 #if 1
 	/* Update endian for next sequence */
-	if (attr_true("renewed", 7)) {
+	sv = attr("renewed", 7);
+	if (SvTRUE(sv)) {
 	    (void)hv_store((HV *)SvRV(obj),"endian",6,newSVpv((char *)&endian,1),0);
 	}
 #endif
@@ -364,7 +371,8 @@ CODE:
 	if (size != 4 && invalid_ucs2(ord)) {
 	    if (!issurrogate(ord)) {
 		if (ucs2 == -1) {
-		    ucs2 = attr_true("ucs2", 4);
+		    SV *sv = attr("ucs2", 4);
+		    ucs2 = SvTRUE(sv);
 		}
 		if (ucs2 || ord > 0x10FFFF) {
 		    if (check) {


### PR DESCRIPTION
All those macros evaluates it arguments more times, so it is not safe to
pass expressions into them. Instead store intermediate result in temporary
variable and pass that temporary variable into those macros.

Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=82348