### PR TITLE
Encode: Rmv impediment to compiling under C++11

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -244,7 +244,7 @@ encode_method(pTHX_ const encode_t * enc, const encpage_t * dir, SV * src, U8 * 
             SV* subchar = 
             (fallback_cb != &PL_sv_undef)
 		? do_fallback_cb(aTHX_ ch, fallback_cb)
-		: newSVpvf(check & ENCODE_PERLQQ ? "\\x{%04"UVxf"}" :
+		: newSVpvf(check & ENCODE_PERLQQ ? "\\x{%04" UVxf "}" :
                  check & ENCODE_HTMLCREF ? "&#%" UVuf ";" :
                  "&#x%" UVxf ";", (UV)ch);
 	    SvUTF8_off(subchar); /* make sure no decoded string gets in */

--- a/Unicode/Unicode.xs
+++ b/Unicode/Unicode.xs
@@ -206,7 +206,7 @@ CODE:
 	    }
 	    if (ucs2 || size == 4) {
 		if (check) {
-		    croak("%"SVf":no surrogates allowed %"UVxf,
+		    croak("%" SVf ":no surrogates allowed %" UVxf,
 			  *hv_fetch((HV *)SvRV(obj),"Name",4,0),
 			  ord);
 		}
@@ -216,7 +216,7 @@ CODE:
 		UV lo;
 		if (!isHiSurrogate(ord)) {
 		    if (check) {
-			croak("%"SVf":Malformed HI surrogate %"UVxf,
+			croak("%" SVf ":Malformed HI surrogate %" UVxf,
 			      *hv_fetch((HV *)SvRV(obj),"Name",4,0),
 			      ord);
 		    }
@@ -231,7 +231,7 @@ CODE:
 		             break;
 		        }
 		        else {
-		             croak("%"SVf":Malformed HI surrogate %"UVxf,
+		             croak("%" SVf ":Malformed HI surrogate %" UVxf,
 				   *hv_fetch((HV *)SvRV(obj),"Name",4,0),
 				   ord);
 		        }
@@ -244,7 +244,7 @@ CODE:
 		    lo = enc_unpack(aTHX_ &s,e,size,endian);
 		    if (!isLoSurrogate(lo)) {
 			if (check) {
-			    croak("%"SVf":Malformed LO surrogate %"UVxf,
+			    croak("%" SVf ":Malformed LO surrogate %" UVxf,
 				  *hv_fetch((HV *)SvRV(obj),"Name",4,0),
 				  ord);
 			}
@@ -262,7 +262,7 @@ CODE:
 
 	if ((ord & 0xFFFE) == 0xFFFE || (ord >= 0xFDD0 && ord <= 0xFDEF)) {
 	    if (check) {
-		croak("%"SVf":Unicode character %"UVxf" is illegal",
+		croak("%" SVf ":Unicode character %" UVxf " is illegal",
 		      *hv_fetch((HV *)SvRV(obj),"Name",4,0),
 		      ord);
 	    } else {
@@ -295,7 +295,7 @@ CODE:
     if (s < e) {
 	/* unlikely to happen because it's fixed-length -- dankogai */
 	if (check & ENCODE_WARN_ON_ERR) {
-	    Perl_warner(aTHX_ packWARN(WARN_UTF8),"%"SVf":Partial character",
+	    Perl_warner(aTHX_ packWARN(WARN_UTF8),"%" SVf ":Partial character",
 			*hv_fetch((HV *)SvRV(obj),"Name",4,0));
 	}
     }
@@ -368,7 +368,7 @@ CODE:
 		}
 		if (ucs2 || ord > 0x10FFFF) {
 		    if (check) {
-			croak("%"SVf":code point \"\\x{%"UVxf"}\" too high",
+			croak("%" SVf ":code point \"\\x{%" UVxf "}\" too high",
 				  *hv_fetch((HV *)SvRV(obj),"Name",4,0),ord);
 		    }
 		    enc_pack(aTHX_ result,size,endian,FBCHAR);
@@ -394,7 +394,7 @@ CODE:
 	   But this is critical when you choose to LEAVE_SRC
 	   in which case we die */
 	if (check & (ENCODE_DIE_ON_ERR|ENCODE_LEAVE_SRC)) {
-	    Perl_croak(aTHX_ "%"SVf":partial character is not allowed "
+	    Perl_croak(aTHX_ "%" SVf ":partial character is not allowed "
 		       "when CHECK = 0x%" UVuf,
 		       *hv_fetch((HV *)SvRV(obj),"Name",4,0), check);
 	}


### PR DESCRIPTION
C++11 changed from earlier versions to require space between the end of
a string literal and a macro, so that a feature can unambiguously be
added to the language.  Starting in g++ 6.2, the compiler emits a
deprecation warning when there isn't a space (presumably so that future
versions can support C++11).

Although not required by the C++11 change, this patch also makes sure
there is space after a macro call, before a string literal.  This makes
the macro stand out, and is easier to read.

Code and modules included with the Perl core need to be compilable using
C++.  This is so that perl can be embedded in C++ programs. (Actually,
only the hdr files need to be so compilable, but it would be hard to
test that just the hdrs are compilable.)  So we need to accommodate
changes to the C++ language.