### PR TITLE
Fix test t/taint.t to pass when Encode::ConfigLocal is present

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl -T
 use strict;
 use Encode qw(encode decode);
+local %Encode::ExtModule = %Encode::Config::ExtModule;
 use Scalar::Util qw(tainted);
 use Test::More;
 my $taint = substr($ENV{PATH},0,0);


### PR DESCRIPTION
Encode::ConfigLocal can load additional encodings which are not part of
Encode distribution and which can be buggy (namely Encode::IBM and
Encode::IMAPUTF7). This fix restore original set of encodings which are
part of Encode only.

Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=103896