### PR TITLE
Fix appending correct number of Unicode replacement characters

### DIFF
--- a/t/fallback.t
+++ b/t/fallback.t
@@ -35,7 +35,7 @@ for my $i (0x80..0xff){
     $uo   .= chr($i);
     $residue    .= chr($i);
     $af .= '?';
-    $uf .= "\x{FFFD}" if $i < 0xfd;
+    $uf .= "\x{FFFD}";
     $ap .= sprintf("\\x{%04x}", $i);
     $up .= sprintf("\\x%02X", $i);
     $ah .= sprintf("&#%d;", $i);

--- a/t/truncated_utf8.t
+++ b/t/truncated_utf8.t
@@ -1,0 +1,45 @@
+BEGIN {
+    if ($ENV{'PERL_CORE'}) {
+        chdir 't';
+        unshift @INC, '../lib';
+    }
+    require Config; import Config;
+    if ($Config{'extensions'} !~ /\bEncode\b/) {
+      print "1..0 # Skip: Encode was not built\n";
+      exit 0;
+    }
+    if (ord("A") == 193) {
+      print "1..0 # Skip: EBCDIC\n";
+      exit 0;
+    }
+    $| = 1;
+}
+
+use strict;
+use warnings;
+
+use Encode;
+use PerlIO::encoding;
+$PerlIO::encoding::fallback &= ~(Encode::WARN_ON_ERR|Encode::PERLQQ);
+
+use Test::More tests => 6;
+
+is(decode("UTF-8", "\xfd\xfe"), "\x{fffd}" x 2);
+is(decode("UTF-8", "\xfd\xfe\xff"), "\x{fffd}" x 3);
+is(decode("UTF-8", "\xfd\xfe\xff\xe0"), "\x{fffd}" x 4);
+is(decode("UTF-8", "\xfd\xfe\xff\xe0\xe1"), "\x{fffd}" x 5);
+
+my $str = ("x" x 1023) . "\xfd\xfe\xffx";
+open my $fh, '<:encoding(UTF-8)', \$str;
+my $str2 = <$fh>;
+close $fh;
+is($str2, ("x" x 1023) . ("\x{fffd}" x 3) . "x");
+
+TODO: {
+    local $TODO = "bug in perlio";
+    my $str = ("x" x 1023) . "\xfd\xfe\xff";
+    open my $fh, '<:encoding(UTF-8)', \$str;
+    my $str2 = <$fh>;
+    close $fh;
+    is($str2, ("x" x 1023) . ("\x{fffd}" x 3));
+}


### PR DESCRIPTION
When truncated UTF-8 sequence was followed by another truncated UTF-8
sequence optionally followed by UTF-8 invariant at the end of string and
first sequence in case it would have been not-truncated is longer as
current string then the whole sequence was replaced just by one Unicode
replacement characters, instead of two (for each invalid/truncated UTF-8
sequence).

This happened also in case Encode was called with STOP_AT_PARTIAL flag.