### PR TITLE
Fix t/truncated_utf8.t test warning: Wide character in print at Test/Builder.pm

### DIFF
--- a/t/truncated_utf8.t
+++ b/t/truncated_utf8.t
@@ -24,6 +24,9 @@ $PerlIO::encoding::fallback &= ~(Encode::WARN_ON_ERR|Encode::PERLQQ);
 
 use Test::More tests => 9;
 
+binmode Test::More->builder->failure_output, ":utf8";
+binmode Test::More->builder->todo_output, ":utf8";
+
 is(decode("UTF-8", "\xfd\xfe"), "\x{fffd}" x 2);
 is(decode("UTF-8", "\xfd\xfe\xff"), "\x{fffd}" x 3);
 is(decode("UTF-8", "\xfd\xfe\xff\xe0"), "\x{fffd}" x 4);


### PR DESCRIPTION
Set failure_output fd and todo_output fd as ":utf8" because error message
contains wide characters.