### PR TITLE
Fix all Encode modules so their encode(undef) and decode(undef) calls returns undef

### DIFF
--- a/lib/Encode/CN/HZ.pm
+++ b/lib/Encode/CN/HZ.pm
@@ -21,6 +21,7 @@ sub needs_lines { 1 }
 
 sub decode ($$;$) {
     my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
 
     my $GB  = Encode::find_encoding('gb2312-raw');
     my $ret = substr($str, 0, 0); # to propagate taintedness
@@ -135,6 +136,7 @@ sub cat_decode {
 
 sub encode($$;$) {
      my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
 
     my $GB  = Encode::find_encoding('gb2312-raw');
     my $ret = substr($str, 0, 0); # to propagate taintedness;

--- a/lib/Encode/GSM0338.pm
+++ b/lib/Encode/GSM0338.pm
@@ -171,6 +171,7 @@ our $NBSP   = "\x{00A0}";
 
 sub decode ($$;$) {
     my ( $obj, $bytes, $chk ) = @_;
+    return undef unless defined $bytes;
     my $str = substr($bytes, 0, 0); # to propagate taintedness;
     while ( length $bytes ) {
         my $c = substr( $bytes, 0, 1, '' );
@@ -216,6 +217,7 @@ sub decode ($$;$) {
 
 sub encode($$;$) {
     my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
     my $bytes = substr($str, 0, 0); # to propagate taintedness
     while ( length $str ) {
         my $u = substr( $str, 0, 1, '' );

--- a/lib/Encode/JP/JIS7.pm
+++ b/lib/Encode/JP/JIS7.pm
@@ -29,6 +29,7 @@ use Encode::CJKConstants qw(:all);
 
 sub decode($$;$) {
     my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
     my $residue = '';
     if ($chk) {
         $str =~ s/([^\x00-\x7f].*)$//so and $residue = $1;
@@ -45,6 +46,7 @@ sub decode($$;$) {
 sub encode($$;$) {
     require Encode::JP::H2Z;
     my ( $obj, $utf8, $chk ) = @_;
+    return undef unless defined $utf8;
 
     # empty the input string in the stack so perlio is ok
     $_[1] = '' if $chk;

--- a/lib/Encode/KR/2022_KR.pm
+++ b/lib/Encode/KR/2022_KR.pm
@@ -16,6 +16,7 @@ sub perlio_ok {
 
 sub decode {
     my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
     my $res     = $str;
     my $residue = iso_euc( \$res );
 
@@ -26,6 +27,7 @@ sub decode {
 
 sub encode {
     my ( $obj, $utf8, $chk ) = @_;
+    return undef unless defined $utf8;
 
     # empty the input string in the stack so perlio is ok
     $_[1] = '' if $chk;

--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -74,6 +74,7 @@ our $STRICT_DECODE = 0;
 
 sub decode($$;$) {
     my ($obj, $str, $chk) = @_;
+    return undef unless defined $str;
 
     my $re_match_decode = $STRICT_DECODE ? $re_match_strict : $re_match;
     my $re_capture_decode = $STRICT_DECODE ? $re_capture_strict : $re_capture;
@@ -202,6 +203,7 @@ sub _decode_octets {
 
 sub encode($$;$) {
     my ($obj, $str, $chk) = @_;
+    return undef unless defined $str;
     my $output = $obj->_fold_line($obj->_encode_string($str, $chk));
     $_[1] = $str if not ref $chk and $chk and !($chk & Encode::LEAVE_SRC);
     return $output . substr($str, 0, 0); # to propagate taintedness

--- a/lib/Encode/MIME/Header/ISO_2022_JP.pm
+++ b/lib/Encode/MIME/Header/ISO_2022_JP.pm
@@ -22,6 +22,7 @@ our $VERSION = do { my @r = ( q$Revision: 1.7 $ =~ /\d+/g ); sprintf "%d." . "%0
 sub encode {
     my $self = shift;
     my $str  = shift;
+    return undef unless defined $str;
 
     utf8::encode($str) if ( Encode::is_utf8($str) );
     Encode::from_to( $str, 'utf8', 'euc-jp' );

--- a/lib/Encode/Unicode/UTF7.pm
+++ b/lib/Encode/Unicode/UTF7.pm
@@ -30,6 +30,7 @@ sub needs_lines { 1 }
 
 sub encode($$;$) {
     my ( $obj, $str, $chk ) = @_;
+    return undef unless defined $str;
     my $len = length($str);
     pos($str) = 0;
     my $bytes = substr($str, 0, 0); # to propagate taintedness
@@ -61,6 +62,7 @@ sub encode($$;$) {
 sub decode($$;$) {
     use re 'taint';
     my ( $obj, $bytes, $chk ) = @_;
+    return undef unless defined $bytes;
     my $len = length($bytes);
     my $str = substr($bytes, 0, 0); # to propagate taintedness;
     pos($bytes) = 0;

--- a/t/undef.t
+++ b/t/undef.t
@@ -1,8 +1,25 @@
-use Encode::Encoder qw(encoder);
+use strict;
+use warnings FATAL => 'all';
 
 use Test::More;
-plan tests => 1;
+
+use Encode qw(encode decode find_encoding);
+use Encode::Encoder qw(encoder);
+
+local %Encode::ExtModule = %Encode::Config::ExtModule;
+
+my @names = Encode->encodings(':all');
+
+plan tests => 1 + 4 * @names;
 
 my $emptyutf8;
 eval { my $c = encoder($emptyutf8)->utf8; };
 ok(!$@,"crashed encoding undef variable ($@)");
+
+for my $name (@names) {
+    my $enc = find_encoding($name);
+    is($enc->encode(undef), undef, "find_encoding('$name')->encode(undef) returns undef");
+    is($enc->decode(undef), undef, "find_encoding('$name')->decode(undef) returns undef");
+    is(encode($name, undef), undef, "encode('$name', undef) returns undef");
+    is(decode($name, undef), undef, "decode('$name', undef) returns undef");
+}


### PR DESCRIPTION
Currently encode and decode methods of more Encode modules returned empty
string for input undef values. This patches fixes it and now both calls

 Encode::find_encoding($enc)->encode(undef);
 Encode::encode($enc, undef);

are equivalent and return undef. Same for decode().

Unit test t/undef.t was extended to verify this state.