### PR TITLE
Call Encode callback function with integer argument correctly

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -124,7 +124,7 @@ do_fallback_cb(pTHX_ UV ch, SV *fallback_cb)
     ENTER;
     SAVETMPS;
     PUSHMARK(sp);
-    XPUSHs(sv_2mortal(newSVnv((UV)ch)));
+    XPUSHs(sv_2mortal(newSVuv(ch)));
     PUTBACK;
     argc = call_sv(fallback_cb, G_SCALAR);
     SPAGAIN;


### PR DESCRIPTION
newSVnv() created scalar with floating point value from unsigned integer
which could loose precision. So use newSVuv() instead.