### PR TITLE
Fix documentation about CHECK coderef

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -915,15 +915,13 @@ octets that represent the fallback character.  For instance:
 
 Acts like C<FB_PERLQQ> but U+I<XXXX> is used instead of C<\x{I<XXXX>}>.
 
-Even the fallback for C<decode> must return octets, which are
-then decoded with the character encoding that C<decode> accepts. So for
+Fallback for C<decode> must return decoded string (sequence of characters). So for
 example if you wish to decode octets as UTF-8, and use ISO-8859-15 as
 a fallback for bytes that are not valid UTF-8, you could write
 
     $str = decode 'UTF-8', $octets, sub {
         my $tmp = chr shift;
-        from_to $tmp, 'ISO-8859-15', 'UTF-8';
-        return $tmp;
+        return decode 'ISO-8859-15', $tmp;
     };
 
 =head1 Defining Encodings


### PR DESCRIPTION
For more then 10 years fallback CHECK coderef for decode() must return
already decoded string and not octets. Returned value is really not later
decoded. So fix documentation and example about this fact.