### PR TITLE
Fixes for Encode::utf8

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -915,12 +915,13 @@ octets that represent the fallback character.  For instance:
 
 Acts like C<FB_PERLQQ> but U+I<XXXX> is used instead of C<\x{I<XXXX>}>.
 
-Fallback for C<decode> must return decoded string (sequence of characters). So for
+Fallback for C<decode> must return decoded string (sequence of characters)
+and takes a list of ordinal values as its arguments. So for
 example if you wish to decode octets as UTF-8, and use ISO-8859-15 as
 a fallback for bytes that are not valid UTF-8, you could write
 
     $str = decode 'UTF-8', $octets, sub {
-        my $tmp = chr shift;
+        my $tmp = join '', map chr, @_;
         return decode 'ISO-8859-15', $tmp;
     };
 

--- a/Encode.xs
+++ b/Encode.xs
@@ -515,17 +515,17 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
             for (i=0; i<ulen; ++i) sprintf(esc+4*i, "\\x%02X", s[i]);
         if (check & ENCODE_DIE_ON_ERR){
             if (encode)
-                Perl_croak(aTHX_ ERR_ENCODE_NOMAP, uv, "utf8");
+                Perl_croak(aTHX_ ERR_ENCODE_NOMAP, uv, (strict ? "UTF-8" : "utf8"));
             else
-                Perl_croak(aTHX_ ERR_DECODE_STR_NOMAP, "utf8", esc);
+                Perl_croak(aTHX_ ERR_DECODE_STR_NOMAP, (strict ? "UTF-8" : "utf8"), esc);
         }
         if (check & ENCODE_WARN_ON_ERR){
             if (encode)
                 Perl_warner(aTHX_ packWARN(WARN_UTF8),
-                            ERR_ENCODE_NOMAP, uv, "utf8");
+                            ERR_ENCODE_NOMAP, uv, (strict ? "UTF-8" : "utf8"));
             else
                 Perl_warner(aTHX_ packWARN(WARN_UTF8),
-                            ERR_DECODE_STR_NOMAP, "utf8", esc);
+                            ERR_DECODE_STR_NOMAP, (strict ? "UTF-8" : "utf8"), esc);
         }
         if (check & ENCODE_RETURN_ON_ERR) {
                 break;

--- a/Encode.xs
+++ b/Encode.xs
@@ -397,7 +397,7 @@ convert_utf8_multi_seq(U8* s, STRLEN len, STRLEN *rlen)
     U8 *ptr = s;
     bool overflowed = 0;
 
-    uv = NATIVE_TO_UTF(*s) & UTF_START_MASK(len);
+    uv = NATIVE_TO_UTF(*s) & UTF_START_MASK(UTF8SKIP(s));
 
     len--;
     s++;

--- a/Encode.xs
+++ b/Encode.xs
@@ -35,17 +35,6 @@ UNIMPLEMENTED(_encoded_bytes_to_utf8, I32)
 #define SvIV_nomg SvIV
 #endif
 
-#ifdef UTF8_DISALLOW_ILLEGAL_INTERCHANGE
-#   define UTF8_ALLOW_STRICT UTF8_DISALLOW_ILLEGAL_INTERCHANGE
-#else
-#   define UTF8_ALLOW_STRICT 0
-#endif
-
-#define UTF8_ALLOW_NONSTRICT (UTF8_ALLOW_ANY &                    \
-                              ~(UTF8_ALLOW_CONTINUATION |         \
-                                UTF8_ALLOW_NON_CONTINUATION |     \
-                                UTF8_ALLOW_LONG))
-
 static void
 Encode_XSEncoding(pTHX_ encode_t * enc)
 {

--- a/MANIFEST
+++ b/MANIFEST
@@ -108,6 +108,7 @@ t/rt86327.t	test script
 t/rt113164.t	test script
 t/taint.t       test script
 t/unibench.pl	benchmark script
+t/utf8messages.t test script
 t/utf8ref.t	test script
 t/utf8strict.t	test script
 t/utf8warnings.t test script

--- a/t/enc_utf8.t
+++ b/t/enc_utf8.t
@@ -26,7 +26,7 @@ use encoding 'utf8';
 
 my @c = (127, 128, 255, 256);
 
-print "1.." . (scalar @c + 1) . "\n";
+print "1.." . (scalar @c + 2) . "\n";
 
 my @f;
 
@@ -59,7 +59,19 @@ binmode(F, ":raw"); # Output raw bytes.
 print F chr(128); # Output illegal UTF-8.
 close F;
 open(F, $f) or die "$0: failed to open '$f' for reading: $!";
-binmode(F, ":encoding(utf-8)");
+binmode(F, ":encoding(UTF-8)");
+{
+    local $^W = 1;
+    local $SIG{__WARN__} = sub { $a = shift };
+    eval { <F> }; # This should get caught.
+}
+close F;
+print $a =~ qr{^UTF-8 "\\x80" does not map to Unicode} ?
+  "ok $t - illegal UTF-8 input\n" : "not ok $t - illegal UTF-8 input: a = " . unpack("H*", $a) . "\n";
+$t++;
+
+open(F, $f) or die "$0: failed to open '$f' for reading: $!";
+binmode(F, ":encoding(utf8)");
 {
     local $^W = 1;
     local $SIG{__WARN__} = sub { $a = shift };
@@ -68,6 +80,7 @@ binmode(F, ":encoding(utf-8)");
 close F;
 print $a =~ qr{^utf8 "\\x80" does not map to Unicode} ?
   "ok $t - illegal utf8 input\n" : "not ok $t - illegal utf8 input: a = " . unpack("H*", $a) . "\n";
+$t++;
 
 # On VMS temporary file names like "f0." may be more readable than "f0" since
 # "f0" could be a logical name pointing elsewhere.

--- a/t/utf8messages.t
+++ b/t/utf8messages.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Encode qw(encode decode FB_CROAK LEAVE_SRC);
+
+plan tests => 12;
+
+my @invalid;
+
+ok ! defined eval { encode('UTF-8', "\x{D800}", FB_CROAK | LEAVE_SRC) }, 'Surrogate codepoint \x{D800} is not encoded to strict UTF-8';
+like $@, qr/^"\\x\{d800\}" does not map to UTF-8 /, 'Error message contains strict UTF-8 name';
+@invalid = ();
+encode('UTF-8', "\x{D800}", sub { @invalid = @_; return ""; });
+is_deeply \@invalid, [ 0xD800 ], 'Fallback coderef contains invalid codepoint 0xD800';
+
+ok ! defined eval { decode('UTF-8', "\xed\xa0\x80", FB_CROAK | LEAVE_SRC) }, 'Surrogate UTF-8 byte sequence \xED\xA0\x80 is decoded with strict UTF-8 decoder';
+like $@, qr/^UTF-8 "\\xED\\xA0\\x80" does not map to Unicode /, 'Error message contains strict UTF-8 name and original (not decoded) invalid sequence';
+@invalid = ();
+decode('UTF-8', "\xed\xa0\x80", sub { @invalid = @_; return ""; });
+is_deeply \@invalid, [ 0xED, 0xA0, 0x80 ], 'Fallback coderef contains invalid byte sequence 0xED, 0xA0, 0x80';
+
+ok ! defined eval { decode('UTF-8', "\xed\xa0", FB_CROAK | LEAVE_SRC) }, 'Invalid byte sequence \xED\xA0 is not decoded with strict UTF-8 decoder';
+like $@, qr/^UTF-8 "\\xED\\xA0" does not map to Unicode /, 'Error message contains strict UTF-8 name and original (not decoded) invalid sequence';
+@invalid = ();
+decode('UTF-8', "\xed\xa0", sub { @invalid = @_; return ""; });
+is_deeply \@invalid, [ 0xED, 0xA0 ], 'Fallback coderef contains invalid byte sequence 0xED, 0xA0';
+
+ok ! defined eval { decode('utf8', "\xed\xa0", FB_CROAK | LEAVE_SRC) }, 'Invalid byte sequence \xED\xA0 is not decoded with non-strict utf8 decoder';
+like $@, qr/^utf8 "\\xED\\xA0" does not map to Unicode /, 'Error message contains non-strict utf8 name and original (not decoded) invalid sequence';
+decode('utf8', "\xed\xa0", sub { @invalid = @_; return ""; });
+is_deeply \@invalid, [ 0xED, 0xA0 ], 'Fallback coderef contains invalid byte sequence 0xED, 0xA0';


### PR DESCRIPTION
Two important changes in this pull request are:

**Encode::utf8: decode: Error message now contains original source sequence**:
* After this change error message for invalid UTF-8 sequence when decoding will contain original invalid sequence in hex format
* Before it was partially decoded Unicode codepoint
* Fallback coderef for decode will now contains in @_ arguments whole invalid UTF-8 sequence and not only first invalid byte
* https://rt.cpan.org/Public/Bug/Display.html?id=36348

**Encode::utf8: Error message in strict mode now contains "UTF-8"**:
* Before this patch in error message was "utf8" as name of encoding
* Now name in error message is chosen by strict mode, either "UTF-8" or "utf8"

And other two are:

**Encode::utf8: Remove defines for UTF8_ALLOW_STRICT and UTF8_ALLOW_NONSTRICT**

**Encode::utf8: Fix applying correct UTF-8 start mask for pathological invalid sequences**

@chansen @khwilliamson Please look at changes and comment or review patches.

I hope that now warning and error messages from Encode::utf8 would be more helpful.