### PR TITLE
Cleanup code for handling fallback/replacement characters

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -457,6 +457,7 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
             continue;
         }
 
+        uv = 0;
         ulen = 1;
         if (! UTF8_IS_CONTINUATION(*s)) {
             /* Not an invariant nor a continuation; must be a start byte.  (We

--- a/Encode.xs
+++ b/Encode.xs
@@ -432,7 +432,7 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
     int check;
     U8 *d;
     STRLEN dlen;
-    char esc[80]; /* need to store UTF8SKIP * 6 + 1 */
+    char esc[UTF8_MAXLEN * 6 + 1];
     int i;
 
     if (SvROK(check_sv)) {


### PR DESCRIPTION
* Avoid magic number
* Initialize uv to safe value
* Fix memory leaks if the callback invoked in call_sv throws an exception
* Throw exception when encode callback returns wide multi-byte character
* Correctly handle scalar from callback regardless of UTF-8 upgradeness
* Fix a bug when downgraded Unicode codepoints between 128-255 from callback were decoded as UTF-8 bytes and upgraded Latin1 chars were also encoded as UTF-8 bytes