### PR TITLE
cperl fixes: encoding undeprecated, no strict hashpairs

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -444,7 +444,7 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
     U8 *d;
     STRLEN dlen;
     char esc[UTF8_MAXLEN * 6 + 1];
-    int i;
+    STRLEN i;
 
     if (SvROK(check_sv)) {
 	/* croak("UTF-8 decoder doesn't support callback CHECK"); */
@@ -483,7 +483,7 @@ process_utf8(pTHX_ SV* dst, U8* s, U8* e, SV *check_sv,
                 else
                     ulen = 1;
 
-                if ((stop_at_partial || (check & ENCODE_STOP_AT_PARTIAL)) && ulen == e-s)
+                if ((stop_at_partial || (check & ENCODE_STOP_AT_PARTIAL)) && ulen == (STRLEN)(e-s))
                     break;
 
                 goto malformed_byte;

--- a/t/enc_eucjp.t
+++ b/t/enc_eucjp.t
@@ -19,8 +19,8 @@ BEGIN {
     print "1..0 # Skip: Perl 5.8.1 or later required\n";
     exit 0;
     }
-    if ($] >= 5.025003){
-    print "1..0 # Skip: Perl 5.25.2 or lower required\n";
+    if ($] >= 5.025003 and !$Config{usecperl}){
+    print "1..0 # Skip: Perl <=5.25.2 or cperl required\n";
     exit 0;
     }
 }

--- a/t/enc_utf8.t
+++ b/t/enc_utf8.t
@@ -15,8 +15,8 @@ BEGIN {
     print "1..0 # encoding pragma does not support EBCDIC platforms\n";
     exit(0);
     }
-    if ($] >= 5.025003){
-    print "1..0 # Skip: Perl 5.25.2 or lower required\n";
+    if ($] >= 5.025003 and !$Config{usecperl}){
+    print "1..0 # Skip: Perl <=5.25.2 or cperl required\n";
     exit 0;
     }
 }


### PR DESCRIPTION
* With cperl encoding is not deprecated
* With cperl 5.27.0 there's a new strict hashpairs mode. https://github.com/perl11/cperl/issues/281