### PR TITLE
Fixes for older perl versions

### DIFF
--- a/t/truncated_utf8.t
+++ b/t/truncated_utf8.t
@@ -35,17 +35,21 @@ is(decode("UTF-8", "\xc1\x9f"), "\x{fffd}");
 is(decode("UTF-8", "\xFF\x80\x90\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80"), "\x{fffd}");
 is(decode("UTF-8", "\xF0\x80\x80\x80"), "\x{fffd}");
 
-my $str = ("x" x 1023) . "\xfd\xfe\xffx";
-open my $fh, '<:encoding(UTF-8)', \$str;
-my $str2 = <$fh>;
-close $fh;
-is($str2, ("x" x 1023) . ("\x{fffd}" x 3) . "x");
-
-TODO: {
-    local $TODO = "bug in perlio";
-    my $str = ("x" x 1023) . "\xfd\xfe\xff";
+SKIP: {
+    # infinite loop due to bug: https://rt.perl.org/Public/Bug/Display.html?id=41442
+    skip "Perl Version ($]) is older than v5.8.9", 2 if $] < 5.008009;
+    my $str = ("x" x 1023) . "\xfd\xfe\xffx";
     open my $fh, '<:encoding(UTF-8)', \$str;
     my $str2 = <$fh>;
     close $fh;
-    is($str2, ("x" x 1023) . ("\x{fffd}" x 3));
+    is($str2, ("x" x 1023) . ("\x{fffd}" x 3) . "x");
+
+    TODO: {
+        local $TODO = "bug in perlio";
+        my $str = ("x" x 1023) . "\xfd\xfe\xff";
+        open my $fh, '<:encoding(UTF-8)', \$str;
+        my $str2 = <$fh>;
+        close $fh;
+        is($str2, ("x" x 1023) . ("\x{fffd}" x 3));
+    }
 }

--- a/t/utf8messages.t
+++ b/t/utf8messages.t
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+BEGIN { 'warnings'->unimport('utf8') if $] < 5.014 }; # turn off 'UTF-16 surrogate 0xd800' warnings
 
 use Test::More;
 use Encode qw(encode decode FB_CROAK LEAVE_SRC);


### PR DESCRIPTION
* Skip tests on older Perl versions which cause infinite loop due to bug: https://rt.perl.org/Public/Bug/Display.html?id=41442
* Turn off t/utf8messages.t warnings which appears only with older Perl versions