### PR TITLE
Run Encode XS BOOT code at compile time

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -190,7 +190,7 @@ sub encode($$;$) {
     else {
         $octets = $enc->encode( $string, $check );
     }
-    $_[1] = $string if $check and !ref $check and !( $check & LEAVE_SRC() );
+    $_[1] = $string if $check and !ref $check and !( $check & LEAVE_SRC );
     return $octets;
 }
 *str2bytes = \&encode;
@@ -219,7 +219,7 @@ sub decode($$;$) {
     else {
         $string = $enc->decode( $octets, $check );
     }
-    $_[1] = $octets if $check and !ref $check and !( $check & LEAVE_SRC() );
+    $_[1] = $octets if $check and !ref $check and !( $check & LEAVE_SRC );
     return $string;
 }
 *bytes2str = \&decode;
@@ -286,7 +286,7 @@ sub decode_utf8($;$) {
     $check   ||= 0;
     $utf8enc ||= find_encoding('utf8');
     my $string = $utf8enc->decode( $octets, $check );
-    $_[0] = $octets if $check and !ref $check and !( $check & LEAVE_SRC() );
+    $_[0] = $octets if $check and !ref $check and !( $check & LEAVE_SRC );
     return $string;
 }
 

--- a/Encode.pm
+++ b/Encode.pm
@@ -4,10 +4,13 @@
 package Encode;
 use strict;
 use warnings;
-our $VERSION = sprintf "%d.%02d", q$Revision: 2.89 $ =~ /(\d+)/g;
 use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
-use XSLoader ();
-XSLoader::load( __PACKAGE__, $VERSION );
+our $VERSION;
+BEGIN {
+    $VERSION = sprintf "%d.%02d", q$Revision: 2.89 $ =~ /(\d+)/g;
+    require XSLoader;
+    XSLoader::load( __PACKAGE__, $VERSION );
+}
 
 use Exporter 5.57 'import';
 
@@ -299,6 +302,7 @@ sub decode_utf8($;$) {
 #     }
 # }
 
+onBOOT;
 predefine_encodings(1);
 
 #

--- a/Encode.xs
+++ b/Encode.xs
@@ -1090,6 +1090,13 @@ CODE:
 OUTPUT:
     RETVAL
 
+void
+onBOOT()
+CODE:
+{
+#include "def_t.exh"
+}
+
 BOOT:
 {
     HV *stash = gv_stashpvn("Encode", strlen("Encode"), GV_ADD);
@@ -1108,7 +1115,4 @@ BOOT:
     newCONSTSUB(stash, "FB_PERLQQ", newSViv(ENCODE_FB_PERLQQ));
     newCONSTSUB(stash, "FB_HTMLCREF", newSViv(ENCODE_FB_HTMLCREF));
     newCONSTSUB(stash, "FB_XMLCREF", newSViv(ENCODE_FB_XMLCREF));
-}
-{
-#include "def_t.exh"
 }


### PR DESCRIPTION
By this change XS functions with prototypes are finally correctly exported. Encodings defined by XS code are now registered by new XS function onBOOT instead from XS BOOT code like described in XSLoader documentation.

Remove parenthesis around constant subs. They are not needed anymore as all XS functions are finally properly exported with defined prototypes.