### PR TITLE
Remove PP stubs and reformat predefine_encodings()

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -591,7 +591,7 @@ MODULE = Encode		PACKAGE = Encode::utf8	PREFIX = Method_
 PROTOTYPES: DISABLE
 
 void
-Method_decode_xs(obj,src,check_sv = &PL_sv_no)
+Method_decode(obj,src,check_sv = &PL_sv_no)
 SV *	obj
 SV *	src
 SV *	check_sv
@@ -655,7 +655,7 @@ CODE:
 }
 
 void
-Method_encode_xs(obj,src,check_sv = &PL_sv_no)
+Method_encode(obj,src,check_sv = &PL_sv_no)
 SV *	obj
 SV *	src
 SV *	check_sv

--- a/Unicode/Unicode.pm
+++ b/Unicode/Unicode.pm
@@ -53,12 +53,6 @@ sub renew {
     return $clone;
 }
 
-# There used to be a perl implementation of (en|de)code but with
-# XS version is ripe, perl version is zapped for optimal speed
-
-*decode = \&decode_xs;
-*encode = \&encode_xs;
-
 1;
 __END__
 

--- a/Unicode/Unicode.xs
+++ b/Unicode/Unicode.xs
@@ -127,7 +127,7 @@ PROTOTYPES: DISABLE
     *hv_fetch((HV *)SvRV(obj),k,l,0) : &PL_sv_undef)
 
 void
-decode_xs(obj, str, check = 0)
+decode(obj, str, check = 0)
 SV *	obj
 SV *	str
 IV	check
@@ -345,7 +345,7 @@ CODE:
 }
 
 void
-encode_xs(obj, utf8, check = 0)
+encode(obj, utf8, check = 0)
 SV *	obj
 SV *	utf8
 IV	check


### PR DESCRIPTION
Encode does not work without XS for a long time, so we do not need PP stubs in code anymore. After removing it allow us to cleanup and reformat boot code in function predefine_encodings().