### PR TITLE
Remove no warnings 'redefine'; and correctly load dependences

### DIFF
--- a/Unicode/Unicode.pm
+++ b/Unicode/Unicode.pm
@@ -2,7 +2,6 @@ package Encode::Unicode;
 
 use strict;
 use warnings;
-no warnings 'redefine';
 
 our $VERSION = do { my @r = ( q$Revision: 2.15 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 
@@ -13,7 +12,7 @@ XSLoader::load( __PACKAGE__, $VERSION );
 # Object Generator 8 transcoders all at once!
 #
 
-require Encode;
+use Encode ();
 
 our %BOM_Unknown = map { $_ => 1 } qw(UTF-16 UTF-32);
 

--- a/lib/Encode/Alias.pm
+++ b/lib/Encode/Alias.pm
@@ -1,9 +1,10 @@
 package Encode::Alias;
 use strict;
 use warnings;
-no warnings 'redefine';
 our $VERSION = do { my @r = ( q$Revision: 2.21 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
+
+use Encode ();
 
 use Exporter 'import';
 
@@ -19,7 +20,6 @@ our @Alias;    # ordered matching list
 our %Alias;    # cached known aliases
 
 sub find_alias {
-    require Encode;
     my $class = shift;
     my $find  = shift;
     unless ( exists $Alias{$find} ) {
@@ -134,7 +134,6 @@ sub undef_aliases {
 }
 
 sub init_aliases {
-    require Encode;
     undef_aliases();
 
     # Try all-lower-case version should all else fails

--- a/lib/Encode/Encoding.pm
+++ b/lib/Encode/Encoding.pm
@@ -7,7 +7,9 @@ our $VERSION = do { my @r = ( q$Revision: 2.7 $ =~ /\d+/g ); sprintf "%d." . "%0
 
 our @CARP_NOT = qw(Encode Encode::Encoder);
 
-require Encode;
+use Carp ();
+use Encode ();
+use Encode::MIME::Name;
 
 sub DEBUG { 0 }
 
@@ -22,12 +24,9 @@ sub Define {
 
 sub name { return shift->{'Name'} }
 
-sub mime_name{
-    require Encode::MIME::Name;
+sub mime_name {
     return Encode::MIME::Name::get_mime_name(shift->name);
 }
-
-# sub renew { return $_[0] }
 
 sub renew {
     my $self = shift;
@@ -58,14 +57,12 @@ sub fromUnicode { shift->encode(@_) }
 #
 
 sub encode {
-    require Carp;
     my $obj = shift;
     my $class = ref($obj) ? ref($obj) : $obj;
     Carp::croak( $class . "->encode() not defined!" );
 }
 
 sub decode {
-    require Carp;
     my $obj = shift;
     my $class = ref($obj) ? ref($obj) : $obj;
     Carp::croak( $class . "->encode() not defined!" );
@@ -190,7 +187,6 @@ MUST return the string representing the canonical name of the encoding.
 Predefined As:
 
   sub mime_name{
-    require Encode::MIME::Name;
     return Encode::MIME::Name::get_mime_name(shift->name);
   }
 

--- a/lib/Encode/Unicode/UTF7.pm
+++ b/lib/Encode/Unicode/UTF7.pm
@@ -4,12 +4,11 @@
 package Encode::Unicode::UTF7;
 use strict;
 use warnings;
-no warnings 'redefine';
 use parent qw(Encode::Encoding);
 __PACKAGE__->Define('UTF-7');
 our $VERSION = do { my @r = ( q$Revision: 2.9 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 use MIME::Base64;
-use Encode;
+use Encode qw(find_encoding);
 
 #
 # Algorithms taken from Unicode::String by Gisle Aas


### PR DESCRIPTION
Calling no warnings 'redefine'; just hide a read problem that one function
is later redefined by another. Such thing should not happen, and if there
is it should be fixed.

The real problem is exporting all Encode functions into used modules,
including functions encode() and decode(). Correct way is to export only
those functions which are really needed by modules. Or to call Encode
function with whole package name (e.g. Encode::find_encoding).

Another problem is time when Encode module is loaded. By calling require it
is done at runtime, after current file was already parsed. It is too late
specially for prototyped functions and also constant. Calling use instead
of require fixes this problem.

After those fixes no warnings 'redefine'; can be removed and modules are
warning-free.