### PR TITLE
Load modules Encode::MIME::Name and Storable normally

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -52,6 +52,8 @@ our $ON_EBCDIC = ( ord("A") == 193 );
 use Encode::Alias;
 use Encode::MIME::Name;
 
+use Storable;
+
 # Make a %Encoding package variable to allow a certain amount of cheating
 our %Encoding;
 our %ExtModule;
@@ -156,8 +158,6 @@ sub resolve_alias($) {
 sub clone_encoding($) {
     my $obj = find_encoding(shift);
     ref $obj or return;
-    eval { require Storable };
-    $@ and return;
     return Storable::dclone($obj);
 }
 

--- a/Encode.pm
+++ b/Encode.pm
@@ -50,6 +50,7 @@ our %EXPORT_TAGS = (
 our $ON_EBCDIC = ( ord("A") == 193 );
 
 use Encode::Alias;
+use Encode::MIME::Name;
 
 # Make a %Encoding package variable to allow a certain amount of cheating
 our %Encoding;
@@ -142,8 +143,6 @@ sub find_encoding($;$) {
 
 sub find_mime_encoding($;$) {
     my ( $mime_name, $skip_external ) = @_;
-    eval { require Encode::MIME::Name; };
-    $@ and return;
     my $name = Encode::MIME::Name::get_encode_name( $mime_name );
     return find_encoding( $name, $skip_external );
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,6 +61,7 @@ WriteMakefile(
     PREREQ_PM   => {
         Exporter   => '5.57',   # use Exporter 'import';
 	parent     => '0.221',  # version bundled with 5.10.1
+        Storable   => '0',      # bundled with Perl 5.7.3
     },
     TEST_REQUIRES => {
         'Test::More' => '0.81_01',


### PR DESCRIPTION
It is not needed to load them conditionally via eval. Encode::MIME::Name is part of Encode and Storable part of Perl since 5.7.3.