### PR TITLE
Encode::MIME::Header: Fix parsing quoted-printable text in strict mode

### DIFF
--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -56,7 +56,7 @@ my $re_capture_encoded_word_split = qr/=\?($re_charset)((?:\*$re_language)?)\?($
 my $re_encoding_strict_b = qr/[Bb]/;
 my $re_encoding_strict_q = qr/[Qq]/;
 my $re_encoded_text_strict_b = qr/[0-9A-Za-z\+\/]*={0,2}/;
-my $re_encoded_text_strict_q = qr/(?:[^\?\s=]|=[0-9A-Fa-f]{2})*/;
+my $re_encoded_text_strict_q = qr/(?:[\x21-\x3C\x3E\x40-\x7E]|=[0-9A-Fa-f]{2})*/; # NOTE: first part are printable US-ASCII except ?, =, SPACE and TAB
 my $re_encoded_word_strict = qr/=\?$re_charset(?:\*$re_language)?\?(?:$re_encoding_strict_b\?$re_encoded_text_strict_b|$re_encoding_strict_q\?$re_encoded_text_strict_q)\?=/;
 my $re_capture_encoded_word_strict = qr/=\?($re_charset)((?:\*$re_language)?)\?($re_encoding_strict_b\?$re_encoded_text_strict_b|$re_encoding_strict_q\?$re_encoded_text_strict_q)\?=/;
 

--- a/t/mime-header.t
+++ b/t/mime-header.t
@@ -24,7 +24,7 @@ use strict;
 use utf8;
 use charnames ":full";
 
-use Test::More tests => 264;
+use Test::More tests => 266;
 
 BEGIN {
     use_ok("Encode::MIME::Header");
@@ -136,6 +136,8 @@ my @decode_default_tests = (
     "=?utf8?Q?=C3=A1=f9=80=80=80=80?=" => "á�",
     "=?UTF8?Q?=C3=A1=f9=80=80=80=80?=" => "á�",
     "=?utf-8-strict?Q?=C3=A1=f9=80=80=80=80?=" => "á�",
+    # allow non-ASCII characters in q word
+    "=?UTF-8?Q?\x{C3}\x{A1}?=" => "á",
 );
 
 my @decode_strict_tests = (
@@ -155,6 +157,8 @@ my @decode_strict_tests = (
     "=?utf8?Q?=C3=A1?=" => "=?utf8?Q?=C3=A1?=",
     "=?UTF8?Q?=C3=A1?=" => "=?UTF8?Q?=C3=A1?=",
     "=?utf-8-strict?Q?=C3=A1?=" => "=?utf-8-strict?Q?=C3=A1?=",
+    # do not allow non-ASCII characters in q word
+    "=?UTF-8?Q?\x{C3}\x{A1}?=" => "=?UTF-8?Q?\x{C3}\x{A1}?=",
 );
 
 my @encode_tests = (


### PR DESCRIPTION
Encoded quoted-printable text can contain only printable US-ASCII
characters except ?, =, SPACE and TAB. Non-strict mode still allows
non-ASCII characters.

@rjbs please look