### PR TITLE
Fix loading Encode::Alias before Encode

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -49,7 +49,7 @@ our %EXPORT_TAGS = (
 
 our $ON_EBCDIC = ( ord("A") == 193 );
 
-use Encode::Alias;
+use Encode::Alias ();
 use Encode::MIME::Name;
 
 use Storable;
@@ -136,6 +136,15 @@ sub getEncoding {
         }
     }
     return;
+}
+
+# HACK: These two functions must be defined in Encode and because of
+# cyclic dependency between Encode and Encode::Alias, Exporter does not work
+sub find_alias {
+    goto &Encode::Alias::find_alias;
+}
+sub define_alias {
+    goto &Encode::Alias::define_alias;
 }
 
 sub find_encoding($;$) {

--- a/MANIFEST
+++ b/MANIFEST
@@ -110,6 +110,7 @@ t/taint.t       test script
 t/truncated_utf8.t test script
 t/undef.t       test script
 t/unibench.pl	benchmark script
+t/use-Encode-Alias.t test script
 t/utf8messages.t test script
 t/utf8ref.t	test script
 t/utf8strict.t	test script

--- a/lib/Encode/Alias.pm
+++ b/lib/Encode/Alias.pm
@@ -4,8 +4,6 @@ use warnings;
 our $VERSION = do { my @r = ( q$Revision: 2.22 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
 use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
 
-use Encode ();
-
 use Exporter 'import';
 
 # Public, encouraged API is exported by default
@@ -108,6 +106,9 @@ sub define_alias {
         }
     }
 }
+
+# HACK: Encode must be used after define_alias is declarated as Encode calls define_alias
+use Encode ();
 
 # Allow latin-1 style names as well
 # 0  1  2  3  4  5   6   7   8   9  10

--- a/t/use-Encode-Alias.t
+++ b/t/use-Encode-Alias.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+
+use Encode::Alias;
+use open ":std", ":locale";
+
+print "1..1\n";
+print "ok 1 - use Encode::Alias works\n";


### PR DESCRIPTION
Calling

  use Encode::Alias;

cased error:

  Undefined subroutine &Encode::define_alias called at lib/Encode.pm line 102.
  Compilation failed in require at lib/Encode/Alias.pm line 7.
  BEGIN failed--compilation aborted at lib/Encode/Alias.pm line 7.
  Compilation failed in require at -e line 1.
  BEGIN failed--compilation aborted at -e line 1.

Fixes #116