### PR TITLE
Utf sanitize

### DIFF
--- a/Encode.pm
+++ b/Encode.pm
@@ -298,6 +298,14 @@ sub decode_utf8($;$) {
     return $string;
 }
 
+sub sanitize_utf8($) {
+    my $string = shift;
+    return $string unless $string;
+    $string = Encode::decode( 'UTF-8', Encode::encode('UTF-8', $string, Encode::FB_DEFAULT ), Encode::FB_CROAK );
+    $string =~ s/[^\x{9}\x{a}\x{d}\x{20}-\x{d7ff}\x{e000}-\x{fffd}\x{10000}-\x{10ffff}]+//g;
+    return $string;
+}
+
 onBOOT;
 
 if ($ON_EBCDIC) {

--- a/t/Encode.t
+++ b/t/Encode.t
@@ -25,8 +25,9 @@ my @character_set = ('0'..'9', 'A'..'Z', 'a'..'z');
 my @source = qw(ascii iso8859-1 cp1250);
 my @destiny = qw(cp1047 cp37 posix-bc);
 my @ebcdic_sets = qw(cp1047 cp37 posix-bc);
-plan tests => 38+$n*@encodings + 2*@source*@destiny*@character_set + 2*@ebcdic_sets*256 + 6 + 3 + 3*8 + 2;
+plan tests => 39+$n*@encodings + 2*@source*@destiny*@character_set + 2*@ebcdic_sets*256 + 6 + 3 + 3*8 + 2;
 
+is Encode::sanitize_utf8("filter \x{006D}alformed 1:\x{1} 2:\x{2} 3:\x{ffff}"), "filter malformed 1: 2: 3:\x{fffd}";
 my $str = join('',map(chr($_),0x20..0x7E));
 my $cpy = $str;
 is length($str),from_to($cpy,'iso8859-1','Unicode'),"Length Wrong";


### PR DESCRIPTION
This function filter malformed characters (Invalid code points) from utf8 string (https://en.wikipedia.org/wiki/UTF-8, https://tools.ietf.org/html/rfc3629).
Use case: user create a file in profile with filename, that consists malformed characters. When we retrieve this file from storage and want to encode_json structure, that contains filename, we get the error:
"malformed or illegal unicode character in string [￿￭￭?], cannot convert to JSON"

Some have questions:
https://stackoverflow.com/questions/6234386/how-do-i-sanitize-invalid-utf-8-in-perl