### PR TITLE
Fix -Werror=declaration-after-statement for gcc 4.1.2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ if (!$ENV{PERL_CORE}) {
     $gccver =~ s/\.//g; $gccver =~ s/ .*//;
     $gccver .= "0" while length $gccver < 3;
     $gccver = 0+$gccver;
-    $ccflags .= ' -Werror=declaration-after-statement' if $gccver > 400;
+    $ccflags .= ' -Werror=declaration-after-statement' if $gccver > 412;
     $ccflags .= ' -Wpointer-sign' if !$Config{d_cplusplus} and $gccver > 400;
     $ccflags .= ' -fpermissive' if $Config{d_cplusplus};
   }


### PR DESCRIPTION
I only checked the docs for the warning on old gcc's, but
apparently they deviate on -Werror=declaration-after-statement support.

Fixes #113