### PR TITLE
Add "euc-cn" => "EUC-CN" alias to Encode::MIME::Name

### DIFF
--- a/lib/Encode/MIME/Name.pm
+++ b/lib/Encode/MIME/Name.pm
@@ -38,6 +38,7 @@ our %MIME_NAME_OF = (
     'cp866'                 => 'IBM866',
     'cp869'                 => 'IBM869',
     'cp936'                 => 'GBK',
+    'euc-cn'                => 'EUC-CN',
     'euc-jp'                => 'EUC-JP',
     'euc-kr'                => 'EUC-KR',
     #'gb2312-raw'            => 'GB2312', # no, you're wrong, I18N::Charset

--- a/t/mime-name.t
+++ b/t/mime-name.t
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 use Encode;
 #use Test::More qw(no_plan);
-use Test::More tests => 277;
+use Test::More tests => 281;
 
 BEGIN {
     use_ok("Encode::MIME::Name");


### PR DESCRIPTION
LWP::UserAgent [uses IO::HTML](https://github.com/libwww-perl/HTTP-Message/blob/master/lib/HTTP/Message.pm#L242-L250) for determining HTML page's encoding and calls `mime_name()` method of the returned Encode::Encoding object.

This fails with Chinese webpages encoded with GB2312. IO::HTML determined the encoding of said pages to be "euc-cn" but it's not mapped to "EUC-CN" in Encode::MIME::Name and so the subsequent content decoding fails.

To reproduce:

```perl
#!/usr/bin/env perl

use strict;
use warnings;
use v5.10;

use LWP::UserAgent;

my $url = 'https://sandbox.pypt.lt/gb2312.html';

my $ua = LWP::UserAgent->new;
my $response = $ua->get($url);

if ($response->is_success) {
    say "Charset: " . $response->content_charset(); # undef; should be "EUC-CN"
    say $response->decoded_content();   # garbled content; should be decoded Chinese text
} else {
    die $response->status_line;
}
```

A simple `'euc-cn' => 'EUC-CN'` mapping fixes everything.