### PR TITLE
enc2xs: Add environment variable to suppress comments

### DIFF
--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -144,6 +144,7 @@ getopts('CM:SQqOo:f:n:v',\%opt);
 $opt{M} and make_makefile_pl($opt{M}, @ARGV);
 $opt{C} and make_configlocal_pm($opt{C}, @ARGV);
 $opt{v} ||= $ENV{ENC2XS_VERBOSE};
+$opt{q} ||= $ENV{ENC2XS_NO_COMMENTS};
 
 sub verbose {
     print STDERR @_ if $opt{v};


### PR DESCRIPTION
Comment generation in enc2xs can now be suppressed by setting the
ENC2XS_NO_COMMENTS environment variable. This allows enc2xs to produce
reproducible output by omitting the name of the generating program.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>