### PR TITLE
Silence unused var warnings from Encode

### DIFF
--- a/Encode.xs
+++ b/Encode.xs
@@ -982,6 +982,7 @@ ALIAS:
 PREINIT:
     SV *obj;
 INIT:
+    PERL_UNUSED_VAR(ix);
     SvGETMAGIC(encoding);
 CODE:
     if (!SvOK(encoding))
@@ -1003,6 +1004,7 @@ ALIAS:
 PREINIT:
     SV *obj;
 INIT:
+    PERL_UNUSED_VAR(ix);
     SvGETMAGIC(encoding);
 CODE:
     if (!SvOK(encoding))


### PR DESCRIPTION
Fix issue https://github.com/Perl/perl5/issues/17536 and
https://github.com/dankogai/p5-encode/issues/146 and
https://github.com/dankogai/p5-encode/issues/140 and
https://github.com/dankogai/p5-encode/issues/143

Aliasing exposes the 'ix' variable. Since the code does not
change behavior based on the alias (which is what aliases are for)
the functions do not access the 'ix' variable, which throws
warnings. Since Encode is core they need to be fixed.

The correct solution to this is to declare the ix variable
unused by using the PERL_UNUSED_VAR(ix); macro, which
this patch does.