### PR TITLE
Ensure that UTF-16 decode always includes a trailing NUL.

### DIFF
--- a/Unicode/Unicode.xs
+++ b/Unicode/Unicode.xs
@@ -361,6 +361,10 @@ CODE:
     }
 
     if (!temp_result) shrink_buffer(result);
+
+    /* Make sure we have a trailing NUL: */
+    *SvEND(result) = '\0';
+
     if (SvTAINTED(str)) SvTAINTED_on(result); /* propagate taintedness */
     XSRETURN(1);
 }

--- a/t/Unicode_trailing_nul.t
+++ b/t/Unicode_trailing_nul.t
@@ -1,0 +1,26 @@
+use strict;
+use Test::More;
+
+use Encode;
+use File::Temp;
+use File::Spec;
+
+# This test relies on https://github.com/Perl/perl5/issues/10623;
+# if that bug is ever fixed then this test may never fail again.
+
+my $foo = Encode::decode("UTF-16LE", "/\0v\0a\0r\0/\0f\0f\0f\0f\0f\0f\0/\0u\0s\0e\0r\0s\0/\0s\0u\0p\0e\0r\0m\0a\0n\0");
+
+my ($fh, $path) = File::Temp::tempfile( CLEANUP => 1 );
+
+diag "temp file: $path";
+
+# Perl gives the internal PV to exec .. which is buggy/wrong but
+# useful here:
+system( $^X, '-e', "open my \$fh, '>>', '$path' or die \$!; print {\$fh} \$ARGV[0]", $foo );
+die if $?;
+
+my $output = do { local $/; <$fh> };
+
+is( $output, "/var/ffffff/users/superman", 'UTF-16 decodes with trailing NUL' );
+
+done_testing();


### PR DESCRIPTION
Issue #159