### PR TITLE
Only add -Werror=declaration-after-statement for 5.035004 and earlier

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ if (!$ENV{PERL_CORE}) {
     $gccver =~ s/\.//g; $gccver =~ s/ .*//;
     $gccver .= "0" while length $gccver < 3;
     $gccver = 0+$gccver;
-    $ccflags .= ' -Werror=declaration-after-statement' if $gccver > 412;
+    $ccflags .= ' -Werror=declaration-after-statement' if $gccver > 412 and $] < 5.035005;
     $ccflags .= ' -Wpointer-sign' if !$Config{d_cplusplus} and $gccver > 400;
     $ccflags .= ' -fpermissive' if $Config{d_cplusplus};
   }


### PR DESCRIPTION
Perl v5.35.5 now uses some C99 features. This means that Perl's headers now contain some code with mixed declarations and code., and so won't compile with -Werror=declaration-after-statement

It still makes sense to add this flag for builds for earlier perl versions, because they support long obsolete compilers that are strict in rejecting certain C99 features, so adding this gcc flag allows us to audit that our code does not violate this.

We didn't need this change **in** blead, because these flags are only added when `$ENV{PERL_CORE}` is false.

Without this change, Encode built from git against blead now fails to build (due to code in blead deliberately changed to find such problems early):

```
/home/nick/Sandpit/snap-v5.35.4-120-gc44af6e357-ig/lib/perl5/5.35.5/x86_64-linux-thread-multi/CORE/inline.h: In function ‘Perl_av_store_simple’:
/home/nick/Sandpit/snap-v5.35.4-120-gc44af6e357-ig/lib/perl5/5.35.5/x86_64-linux-thread-multi/CORE/inline.h:91:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
     SV **ary = AvARRAY(av);
     ^~
cc1: some warnings being treated as errors
```