### PR TITLE
Use note() instead of diag()

### DIFF
--- a/t/Unicode_trailing_nul.t
+++ b/t/Unicode_trailing_nul.t
@@ -12,7 +12,7 @@ my $foo = Encode::decode("UTF-16LE", "/\0v\0a\0r\0/\0f\0f\0f\0f\0f\0f\0/\0u\0s\0
 
 my ($fh, $path) = File::Temp::tempfile( CLEANUP => 1 );
 
-diag "temp file: $path";
+note "temp file: $path";
 
 # Perl gives the internal PV to exec .. which is buggy/wrong but
 # useful here:


### PR DESCRIPTION
In the documentation for Test::More, the note() function is described as
"Handy for putting in notes which might be useful for debugging, but
don't indicate a problem."  diag() is mainly intended to be used in
situations where a unit test has failed and more diagnostic output would
be helpful in debugging.

Here, we're simply making a note of the name of the tempfile created
during testing, so note() is more appropriate.

In addition, note() prints to STDOUT when the tests are run as part of a
harness; diag() prints to STDERR.  When Encode's test suite is run as
part of the Perl 5 core distribution's test suite, this diag() statement
is the *only* statement that gets printed to STDERR.  Once this p.r. is
applied, a new version of Encode is released to CPAN, and that version
is synched into blead, then Perl's test suite will run entirely to
STDOUT.