### PR TITLE
Fix Issue #144, spurious warnings from -Wc++-compate, and a few related nits

### DIFF
--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -254,7 +254,7 @@ END
     print C qq(#pragma GCC diagnostic ignored "-Wc++-compat"\n);
    }
 
-  if ($cname =~ /(\w+)\.xs$/)
+  if ($cname =~ /\.xs$/i)
    {
     print C "#define PERL_NO_GET_CONTEXT\n";
     print C "#include <EXTERN.h>\n";
@@ -264,15 +264,15 @@ END
   print C "#include \"encode.h\"\n\n";
 
  }
-elsif ($cname =~ /\.enc$/)
+elsif ($cname =~ /\.enc$/i)
  {
   $doEnc = 1;
  }
-elsif ($cname =~ /\.ucm$/)
+elsif ($cname =~ /\.ucm$/i)
  {
   $doUcm = 1;
  }
-elsif ($cname =~ /\.pet$/)
+elsif ($cname =~ /\.pet$/i)
  {
   $doPet = 1;
  }

--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -249,6 +249,11 @@ if ($cname =~ /\.(c|xs)$/i) # VMS may have upcased filenames with DECC$ARGV_PARS
 END
   }
 
+  if ($cname =~ /\.c$/i && $Config{ccname} eq "gcc")
+   {
+    print C qq(#pragma GCC diagnostic ignored "-Wc++-compat"\n);
+   }
+
   if ($cname =~ /(\w+)\.xs$/)
    {
     print C "#define PERL_NO_GET_CONTEXT\n";

--- a/t/enc_data.t
+++ b/t/enc_data.t
@@ -15,7 +15,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
     if ($] <= 5.008 and !$Config{perl_patchlevel}){

--- a/t/enc_module.t
+++ b/t/enc_module.t
@@ -19,7 +19,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
 }

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -13,7 +13,7 @@ BEGIN {
     exit(0);
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
 }

--- a/t/jperl.t
+++ b/t/jperl.t
@@ -18,7 +18,7 @@ BEGIN {
     exit 0;
     }
     if ($] >= 5.025 and !$Config{usecperl}) {
-    print "1..0 # Skip: encoding pragma not supported in Perl 5.26\n";
+    print "1..0 # Skip: encoding pragma not supported in Perl 5.25 or later\n";
     exit(0);
     }
     $| = 1;


### PR DESCRIPTION
This silences the copious warnings produced by modern versions of gcc when compiling with -Wc++-compat. These warnings are bogus as the code actually has different codepaths via defines for C++ and C, so warning about C code that wont compile in C++ is not helpful. 

This also fixes a few other minor nits I noticed when building and testing. 

The Perl issue this fixes is: https://github.com/Perl/perl5/issues/19588
The Encode issues this fixes is: https://github.com/dankogai/p5-encode/issues/144