### PR TITLE
Encode::MIME::Header: Fix base64 word decoding

### DIFF
--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -94,6 +94,10 @@ sub decode($$;$) {
 
         $stop = 1 unless length($line) or length($sep);
 
+        # in non strict mode append missing '=' padding characters for b words
+        # fixes below concatenation of consecutive encoded mime words
+        1 while not $STRICT_DECODE and $line =~ s/(=\?$re_charset(?:\*$re_language)?\?[Bb]\?)((?:[^\?]{4})*[^\?]{1,3})(\?=)/$1.$2.('='x(4-length($2)%4)).$3/se;
+
         # NOTE: this code partially could break $chk support
         # in non strict mode concat consecutive encoded mime words with same charset, language and encoding
         # fixes breaking inside multi-byte characters

--- a/lib/Encode/MIME/Header.pm
+++ b/lib/Encode/MIME/Header.pm
@@ -55,7 +55,7 @@ my $re_capture_encoded_word_split = qr/=\?($re_charset)((?:\*$re_language)?)\?($
 # in strict mode check also for valid base64 characters and also for valid quoted printable codes
 my $re_encoding_strict_b = qr/[Bb]/;
 my $re_encoding_strict_q = qr/[Qq]/;
-my $re_encoded_text_strict_b = qr/[0-9A-Za-z\+\/]*={0,2}/;
+my $re_encoded_text_strict_b = qr/(?:[0-9A-Za-z\+\/]{4})*(?:[0-9A-Za-z\+\/]{2}==|[0-9A-Za-z\+\/]{3}=|)/;
 my $re_encoded_text_strict_q = qr/(?:[\x21-\x3C\x3E\x40-\x7E]|=[0-9A-Fa-f]{2})*/; # NOTE: first part are printable US-ASCII except ?, =, SPACE and TAB
 my $re_encoded_word_strict = qr/=\?$re_charset(?:\*$re_language)?\?(?:$re_encoding_strict_b\?$re_encoded_text_strict_b|$re_encoding_strict_q\?$re_encoded_text_strict_q)\?=/;
 my $re_capture_encoded_word_strict = qr/=\?($re_charset)((?:\*$re_language)?)\?($re_encoding_strict_b\?$re_encoded_text_strict_b|$re_encoding_strict_q\?$re_encoded_text_strict_q)\?=/;

--- a/t/mime-header.t
+++ b/t/mime-header.t
@@ -24,7 +24,7 @@ use strict;
 use utf8;
 use charnames ":full";
 
-use Test::More tests => 266;
+use Test::More tests => 270;
 
 BEGIN {
     use_ok("Encode::MIME::Header");
@@ -159,6 +159,11 @@ my @decode_strict_tests = (
     "=?utf-8-strict?Q?=C3=A1?=" => "=?utf-8-strict?Q?=C3=A1?=",
     # do not allow non-ASCII characters in q word
     "=?UTF-8?Q?\x{C3}\x{A1}?=" => "=?UTF-8?Q?\x{C3}\x{A1}?=",
+    # do not allow missing padding characters '=' in b word
+    "=?UTF-8?B?JQ?=" => "=?UTF-8?B?JQ?=",
+    "=?UTF-8?B?JQ?= =?UTF-8?B?JQ?=" => "=?UTF-8?B?JQ?= =?UTF-8?B?JQ?=",
+    "=?UTF-8?B?YWI?=" => "=?UTF-8?B?YWI?=",
+    "=?UTF-8?B?YWI?= =?UTF-8?B?YWI?=" => "=?UTF-8?B?YWI?= =?UTF-8?B?YWI?=",
 );
 
 my @encode_tests = (

--- a/t/mime-header.t
+++ b/t/mime-header.t
@@ -24,7 +24,7 @@ use strict;
 use utf8;
 use charnames ":full";
 
-use Test::More tests => 270;
+use Test::More tests => 274;
 
 BEGIN {
     use_ok("Encode::MIME::Header");
@@ -138,6 +138,11 @@ my @decode_default_tests = (
     "=?utf-8-strict?Q?=C3=A1=f9=80=80=80=80?=" => "á�",
     # allow non-ASCII characters in q word
     "=?UTF-8?Q?\x{C3}\x{A1}?=" => "á",
+    # allow missing padding characters '=' in b word
+    "=?UTF-8?B?JQ?=" => "%",
+    "=?UTF-8?B?JQ?= =?UTF-8?B?JQ?=" => "%%",
+    "=?UTF-8?B?YWI?=" => "ab",
+    "=?UTF-8?B?YWI?= =?UTF-8?B?YWI?=" => "abab",
 );
 
 my @decode_strict_tests = (


### PR DESCRIPTION
* Do not allow decoding base64 text with missing padding characters '=' in strict mode.
* Allow missing padding base64 characters in default non-strict mode