### PR TITLE
fix gsm0338 test compatibility with perl < 5.8.8

### DIFF
--- a/t/gsm0338.t
+++ b/t/gsm0338.t
@@ -16,6 +16,10 @@ use utf8;
 use Test::More tests => 777;
 use Encode;
 use Encode::GSM0338;
+use PerlIO::encoding;
+
+# perl < 5.8.8 didn't enable STOP_AT_PARTIAL by default
+$PerlIO::encoding::fallback |= Encode::STOP_AT_PARTIAL;
 
 my $chk = Encode::LEAVE_SRC();
 


### PR DESCRIPTION
Prior to perl 5.8.8, the :encoding PerlIO layer did not enable STOP_AT_PARTIAL by default. Set it to make sure our test works properly.