### PR TITLE
Skip taint tests when -DSILENT_NO_TAINT_SUPPORT is enabled.

### DIFF
--- a/t/taint.t
+++ b/t/taint.t
@@ -12,7 +12,10 @@ my $notaint = "";
 my $notaint_str = "dan\x{5f3e}" . $notaint;
 my $notaint_bin = encode('UTF-8', $notaint_str);
 my @names = Encode->encodings(':all');
-if (exists($Config{taint_support}) && not $Config{taint_support}) {
+if (
+    (exists($Config{taint_support}) && not $Config{taint_support}) ||
+    $Config{ccflags} =~ /-DSILENT_NO_TAINT_SUPPORT/
+) {
     plan skip_all => "your perl was built without taint support";
 }
 else {


### PR DESCRIPTION
If perl is built with -DSILENT_NO_TAINT_SUPPORT checking `$Config{taint_support}` isn't enough, this adds a check that looks for -DSILENT_NO_TAINT_SUPPORT in `$Config{ccflags}`.