### PR TITLE
`enc2xs`: Fix indirect syntax

### DIFF
--- a/bin/enc2xs
+++ b/bin/enc2xs
@@ -3,7 +3,7 @@ BEGIN {
     # @INC poking  no longer needed w/ new MakeMaker and Makefile.PL's
     # with $ENV{PERL_CORE} set
     # In case we need it in future...
-    require Config; import Config;
+    require Config; Config->import;
     pop @INC if $INC[-1] eq '.';
 }
 use strict;


### PR DESCRIPTION
As the indirect object syntax in discouraged