### PR TITLE
Restore correct revision subheader for 3.22

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@ $Revision: 3.23 $ $Date: 2026/04/27 03:01:25 $
   readdress RT#152013: Unicode_trailing_nul.t leaves a temp file
   https://github.com/dankogai/p5-encode/commit/f01eac7df7185a836ca5825d7bf2bd9510a3826b
 
-$Revision: 3.23 $ $Date: 2026/04/27 03:01:25 $
+$Revision: 3.22 $ $Date: 2026/04/25 16:36:51 $
 ! lib/Encode/Supported.pod
   Pulled: Encode::Supported: fix broken link
   https://github.com/dankogai/p5-encode/pull/182


### PR DESCRIPTION
While attempting to synch Encode-3.23 into the Perl 5 core distribution, I noticed two subsection headers for Revision 3.23 in Changes.
```
  $ git diff 3.22..3.23 -- Changes
  diff --git a/Changes b/Changes
  index d460234..ed6a785 100644
  --- a/Changes
  +++ b/Changes
  @@ -1,8 +1,13 @@
   # Revision history for Perl extension Encode.
   #
  -# $Id: Changes,v 3.22 2026/04/25 16:36:51 dankogai Exp $
  +# $Id: Changes,v 3.23 2026/04/27 03:01:25 dankogai Exp dankogai $
   #
  -$Revision: 3.22 $ $Date: 2026/04/25 16:36:51 $
  +$Revision: 3.23 $ $Date: 2026/04/27 03:01:25 $
  +! t/Unicode_trailing_nul.t
  +  readdress RT#152013: Unicode_trailing_nul.t leaves a temp file
  +  https://github.com/dankogai/p5-encode/commit/f01eac7df7185a836ca5825d7bf2bd9510a3826b + +$Revision: 3.23 $ $Date: 2026/04/27 03:01:25 $ ! lib/Encode/Supported.pod Pulled: Encode::Supported: fix broken link https://github.com/dankogai/p5-encode/pull/182
```