### PR TITLE
Byte/Makefile.PL: ensure build reproducibility again

### DIFF
--- a/Byte/Makefile.PL
+++ b/Byte/Makefile.PL
@@ -171,7 +171,7 @@ sub postamble
     my $lengthsofar = length($str);
     my $continuator = '';
     $str .= "$table.c : $enc2xs Makefile.PL";
-    foreach my $file (@{$tables{$table}})
+    foreach my $file (sort (@{$tables{$table}}))
     {
         $str .= $continuator.' '.$self->catfile($dir,$file);
         if ( length($str)-$lengthsofar > 128*$numlines )
@@ -189,7 +189,7 @@ sub postamble
         qq{\n\t\$(PERL) $plib $enc2xs $ucopts -o \$\@ -f $table.fnm\n\n};
     open (FILELIST, ">$table.fnm")
         || die "Could not open $table.fnm: $!";
-    foreach my $file (@{$tables{$table}})
+    foreach my $file (sort (@{$tables{$table}}))
     {
         print FILELIST $self->catfile($dir,$file) . "\n";
     }


### PR DESCRIPTION
1009a934c1f8f599880d7ad262cbeb4dcab3f943 caused #179 to be lost. This PR re-applies it.